### PR TITLE
Fix libssh2_agent_init detection

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -42,7 +42,7 @@ if test "$PHP_SSH2" != "no"; then
   ],[
     AC_MSG_WARN([libssh2 <= 1.2.3, ssh-agent subsystem support not enabled])
   ],[
-    -L$SSH2_DIR/lib -lm	     -L$SSH2_DIR/lib -lm
+    -L$SSH2_DIR/lib -lm
   ])
 
   PHP_CHECK_LIBRARY(ssh2,libssh2_session_set_timeout,


### PR DESCRIPTION
The extra variable causes the "-L$SSH2_DIR/lib -lm" parameter not to be used, so ld doesn't find the ssh2 lib.
