### PR TITLE
Fix for ssh2_exec(): Unable to request a channel from remote host

### DIFF
--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -468,6 +468,8 @@ static php_stream *php_ssh2_shell_open(LIBSSH2_SESSION *session, int resource_id
 	php_ssh2_channel_data *channel_data;
 	php_stream *stream;
 
+	libssh2_session_set_blocking(session, 1);
+
 	channel = libssh2_channel_open_session(session);
 	if (!channel) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to request a channel from remote host");
@@ -711,6 +713,8 @@ static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session, int resource_
 	LIBSSH2_CHANNEL *channel;
 	php_ssh2_channel_data *channel_data;
 	php_stream *stream;
+
+	libssh2_session_set_blocking(session, 1);
 
 	channel = libssh2_channel_open_session(session);
 	if (!channel) {


### PR DESCRIPTION
We need to set session to blocking mode before calling libssh2_channel_open_session().

This fixes long standing issue of ssh2_exec() failing with 'Unable to request a channel from remote host' when invoked for second time using same session. - https://bugs.php.net/bug.php?id=58893
ssh2_shell() has same construct, so same approach is applied there too.