### PR TITLE
Bugfix PHP 7 support

### DIFF
--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -25,7 +25,7 @@
 #include <libssh2_sftp.h>
 #include "ext/standard/url.h"
 
-#define PHP_SSH2_VERSION					"1.0+dev"
+#define PHP_SSH2_VERSION				"1.0+dev"
 #define PHP_SSH2_DEFAULT_PORT			22
 
 /* Exported Constants */
@@ -167,15 +167,6 @@ extern php_stream_wrapper php_ssh2_sftp_wrapper;
 extern int le_ssh2_session;
 extern int le_ssh2_sftp;
 
-/* {{{ ZIP_OPENBASEDIR_CHECKPATH(filename) */
-#if PHP_API_VERSION < 20100412
-# define SSH2_OPENBASEDIR_CHECKPATH(filename) \
-	(PG(safe_mode) && (!php_checkuid(filename, NULL, CHECKUID_CHECK_FILE_AND_DIR))) || php_check_open_basedir(filename TSRMLS_CC)
-#else
-#define SSH2_OPENBASEDIR_CHECKPATH(filename) \
-	php_check_open_basedir(filename TSRMLS_CC)
-#endif
-/* }}} */
 #endif	/* PHP_SSH2_H */
 
 

--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -25,8 +25,8 @@
 #include <libssh2_sftp.h>
 #include "ext/standard/url.h"
 
-#define PHP_SSH2_VERSION        "1.0+dev"
-#define PHP_SSH2_DEFAULT_PORT   22
+#define PHP_SSH2_VERSION					"1.0+dev"
+#define PHP_SSH2_DEFAULT_PORT			22
 
 /* Exported Constants */
 #define PHP_SSH2_FINGERPRINT_MD5		0x0000
@@ -70,17 +70,17 @@ typedef struct _php_ssh2_session_data {
 } php_ssh2_session_data;
 
 typedef struct _php_ssh2_sftp_data {
-    LIBSSH2_SESSION *session;
-    LIBSSH2_SFTP *sftp;
+	LIBSSH2_SESSION *session;
+	LIBSSH2_SFTP *sftp;
 
-    int session_rsrcid;
+	int session_rsrcid;
 } php_ssh2_sftp_data;
 
 typedef struct _php_ssh2_listener_data {
-    LIBSSH2_SESSION *session;
-    LIBSSH2_LISTENER *listener;
+	LIBSSH2_SESSION *session;
+	LIBSSH2_LISTENER *listener;
 
-    int session_rsrcid;
+	int session_rsrcid;
 } php_ssh2_listener_data;
 
 #include "libssh2_publickey.h"
@@ -94,7 +94,7 @@ typedef struct _php_ssh2_pkey_subsys_data {
 
 #define SSH2_FETCH_NONAUTHENTICATED_SESSION(session, zsession) \
 if ((session = (LIBSSH2_SESSION *)zend_fetch_resource(Z_RES_P(zsession), PHP_SSH2_SESSION_RES_NAME, le_ssh2_session)) == NULL) { \
-    RETURN_FALSE; \
+	RETURN_FALSE; \
 } \
 if (libssh2_userauth_authenticated(session)) { \
 	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Connection already authenticated"); \
@@ -103,7 +103,7 @@ if (libssh2_userauth_authenticated(session)) { \
 
 #define SSH2_FETCH_AUTHENTICATED_SESSION(session, zsession) \
 if ((session = (LIBSSH2_SESSION *)zend_fetch_resource(Z_RES_P(zsession), PHP_SSH2_SESSION_RES_NAME, le_ssh2_session)) == NULL) { \
-    RETURN_FALSE; \
+	RETURN_FALSE; \
 } \
 if (!libssh2_userauth_authenticated(session)) { \
 	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Connection not authenticated"); \

--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -97,7 +97,7 @@ if ((session = (LIBSSH2_SESSION *)zend_fetch_resource(Z_RES_P(zsession), PHP_SSH
 	RETURN_FALSE; \
 } \
 if (libssh2_userauth_authenticated(session)) { \
-	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Connection already authenticated"); \
+	php_error_docref(NULL, E_WARNING, "Connection already authenticated"); \
 	RETURN_FALSE; \
 }
 
@@ -106,7 +106,7 @@ if ((session = (LIBSSH2_SESSION *)zend_fetch_resource(Z_RES_P(zsession), PHP_SSH
 	RETURN_FALSE; \
 } \
 if (!libssh2_userauth_authenticated(session)) { \
-	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Connection not authenticated"); \
+	php_error_docref(NULL, E_WARNING, "Connection not authenticated"); \
 	RETURN_FALSE; \
 }
 
@@ -148,12 +148,11 @@ PHP_FUNCTION(ssh2_sftp_symlink);
 PHP_FUNCTION(ssh2_sftp_readlink);
 PHP_FUNCTION(ssh2_sftp_realpath);
 
-LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, zval *callbacks TSRMLS_DC);
-void php_ssh2_sftp_dtor(zend_resource *rsrc TSRMLS_DC);
+LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, zval *callbacks);
+void php_ssh2_sftp_dtor(zend_resource *rsrc);
 php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stream_context *context,
 											LIBSSH2_SESSION **psession, int *presource_id,
-											LIBSSH2_SFTP **psftp, int *psftp_rsrcid
-											TSRMLS_DC);
+											LIBSSH2_SFTP **psftp, int *psftp_rsrcid);
 
 extern php_stream_ops php_ssh2_channel_stream_ops;
 

--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -1,22 +1,22 @@
 /*
-  +----------------------------------------------------------------------+
-  | PHP Version 4                                                        |
-  +----------------------------------------------------------------------+
-  | Copyright (c) 1997-2006 The PHP Group                                |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.01 of the PHP license,      |
-  | that is bundled with this package in the file LICENSE, and is        |
-  | available at through the world-wide-web at                           |
-  | http://www.php.net/license/3_01.txt.                                 |
-  | If you did not receive a copy of the PHP license and are unable to   |
-  | obtain it through the world-wide-web, please send a note to          |
-  | license@php.net so we can mail you a copy immediately.               |
-  +----------------------------------------------------------------------+
-  | Author: Sara Golemon <pollita@php.net>                               |
-  +----------------------------------------------------------------------+
-
-  $Id$
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2016 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author: Sara Golemon <pollita@php.net>                               |
+   +----------------------------------------------------------------------+
 */
+
+/* $Id$ */
 
 #ifndef PHP_SSH2_H
 #define PHP_SSH2_H

--- a/ssh2.c
+++ b/ssh2.c
@@ -890,8 +890,7 @@ PHP_FUNCTION(ssh2_poll)
 		}
 		zend_string_release(hash_key_zstring);
 
-		//TODO Sean-Der
-		//zend_list_find(Z_LVAL_P(tmpzval), &res_type);
+		res_type = Z_RES_P(tmpzval)->type;
 		res = zend_fetch_resource_ex(tmpzval, "Poll Resource", res_type);
 		if (res_type == le_ssh2_listener) {
 			pollfds[i].type = LIBSSH2_POLLFD_LISTENER;
@@ -902,8 +901,7 @@ PHP_FUNCTION(ssh2_poll)
 			pollfds[i].fd.channel = ((php_ssh2_channel_data*)(((php_stream*)res)->abstract))->channel;
 			/* TODO: Add the ability to select against other stream types */
 		} else {
-			// TODO Sean-Der
-			//php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid resource type in subarray: %s", zend_rsrc_list_get_rsrc_type(Z_LVAL_PP(tmpzval) TSRMLS_CC));
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid resource type in subarray: %s", zend_rsrc_list_get_rsrc_type(Z_RES_P(tmpzval)));
 			numfds--;
 			continue;
 		}

--- a/ssh2.c
+++ b/ssh2.c
@@ -102,8 +102,8 @@ LIBSSH2_DEBUG_FUNC(php_ssh2_debug_cb)
 	ZVAL_STRINGL(&args[1], language, language_len);
 	ZVAL_LONG(&args[2], always_display);
 
-	if (FAILURE == call_user_function_ex(NULL, NULL, data->disconnect_cb, NULL, 3, args, 0, NULL TSRMLS_CC)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure calling disconnect callback");
+	if (FAILURE == call_user_function_ex(NULL, NULL, data->disconnect_cb, NULL, 3, args, 0, NULL)) {
+		php_error_docref(NULL, E_WARNING, "Failure calling disconnect callback");
 	}
 }
 /* }}} */
@@ -127,8 +127,8 @@ LIBSSH2_IGNORE_FUNC(php_ssh2_ignore_cb)
 
 	ZVAL_STRINGL(&args[0], message, message_len);
 
-	if (FAILURE == call_user_function_ex(NULL, NULL, data->ignore_cb, &zretval, 1, args, 0, NULL TSRMLS_CC)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure calling ignore callback");
+	if (FAILURE == call_user_function_ex(NULL, NULL, data->ignore_cb, &zretval, 1, args, 0, NULL)) {
+		php_error_docref(NULL, E_WARNING, "Failure calling ignore callback");
 	}
 	if (Z_TYPE_P(&zretval) != IS_UNDEF) {
 		zval_ptr_dtor(&zretval);
@@ -157,8 +157,8 @@ LIBSSH2_MACERROR_FUNC(php_ssh2_macerror_cb)
 
 	ZVAL_STRINGL(&args[0], packet, packet_len);
 
-	if (FAILURE == call_user_function_ex(NULL, NULL, data->macerror_cb, &zretval, 1, args, 0, NULL TSRMLS_CC)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure calling macerror callback");
+	if (FAILURE == call_user_function_ex(NULL, NULL, data->macerror_cb, &zretval, 1, args, 0, NULL)) {
+		php_error_docref(NULL, E_WARNING, "Failure calling macerror callback");
 	} else {
 		retval = zval_is_true(&zretval) ? 0 : -1;
 	}
@@ -190,8 +190,8 @@ LIBSSH2_DISCONNECT_FUNC(php_ssh2_disconnect_cb)
 	ZVAL_STRINGL(&args[1], message, message_len);
 	ZVAL_STRINGL(&args[2], language, language_len);
 
-	if (FAILURE == call_user_function_ex(NULL, NULL, data->disconnect_cb, NULL, 3, args, 0, NULL TSRMLS_CC)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure calling disconnect callback");
+	if (FAILURE == call_user_function_ex(NULL, NULL, data->disconnect_cb, NULL, 3, args, 0, NULL)) {
+		php_error_docref(NULL, E_WARNING, "Failure calling disconnect callback");
 	}
 }
 /* }}} */
@@ -205,7 +205,7 @@ LIBSSH2_DISCONNECT_FUNC(php_ssh2_disconnect_cb)
 /* {{{ php_ssh2_set_callback
  * Try to set a method if it's passed in with the hash table
  */
-static int php_ssh2_set_callback(LIBSSH2_SESSION *session, HashTable *ht, char *callback, int callback_len, int callback_type, php_ssh2_session_data *data TSRMLS_DC)
+static int php_ssh2_set_callback(LIBSSH2_SESSION *session, HashTable *ht, char *callback, int callback_len, int callback_type, php_ssh2_session_data *data)
 {
 	zval *handler, *copyval;
 	void *internal_handler;
@@ -292,7 +292,7 @@ static int php_ssh2_set_method(LIBSSH2_SESSION *session, HashTable *ht, char *me
 /* {{{ php_ssh2_session_connect
  * Connect to an SSH server with requested methods
  */
-LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, zval *callbacks TSRMLS_DC)
+LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, zval *callbacks)
 {
 	LIBSSH2_SESSION *session;
 	int socket;
@@ -306,7 +306,7 @@ LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, z
 	socket = php_network_connect_socket_to_host(host, port, SOCK_STREAM, 0, &tv, NULL, NULL, NULL, 0, STREAM_SOCKOP_NONE);
 
 	if (socket <= 0) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to connect to %s on port %d", host, port);
+		php_error_docref(NULL, E_WARNING, "Unable to connect to %s on port %d", host, port);
 		return NULL;
 	}
 
@@ -315,7 +315,7 @@ LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, z
 
 	session = libssh2_session_init_ex(php_ssh2_alloc_cb, php_ssh2_free_cb, php_ssh2_realloc_cb, data);
 	if (!session) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to initialize SSH2 session");
+		php_error_docref(NULL, E_WARNING, "Unable to initialize SSH2 session");
 		efree(data);
 		closesocket(socket);
 		return NULL;
@@ -327,25 +327,25 @@ LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, z
 		zval *container;
 
 		if (php_ssh2_set_method(session, HASH_OF(methods), "kex", sizeof("kex") - 1, LIBSSH2_METHOD_KEX)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding KEX method");
+			php_error_docref(NULL, E_WARNING, "Failed overriding KEX method");
 		}
 		if (php_ssh2_set_method(session, HASH_OF(methods), "hostkey", sizeof("hostkey") - 1, LIBSSH2_METHOD_HOSTKEY)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding HOSTKEY method");
+			php_error_docref(NULL, E_WARNING, "Failed overriding HOSTKEY method");
 		}
 
 		hash_lookup_zstring = zend_string_init("client_to_server", sizeof("client_to_server") - 1, 0);
 		if ((container = zend_hash_find(HASH_OF(methods), hash_lookup_zstring)) != NULL && Z_TYPE_P(container) == IS_ARRAY) {
 			if (php_ssh2_set_method(session, HASH_OF(container), "crypt", sizeof("crypt") - 1, LIBSSH2_METHOD_CRYPT_CS)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding client to server CRYPT method");
+				php_error_docref(NULL, E_WARNING, "Failed overriding client to server CRYPT method");
 			}
 			if (php_ssh2_set_method(session, HASH_OF(container), "mac", sizeof("mac") - 1, LIBSSH2_METHOD_MAC_CS)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding client to server MAC method");
+				php_error_docref(NULL, E_WARNING, "Failed overriding client to server MAC method");
 			}
 			if (php_ssh2_set_method(session, HASH_OF(container), "comp", sizeof("comp") - 1, LIBSSH2_METHOD_COMP_CS)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding client to server COMP method");
+				php_error_docref(NULL, E_WARNING, "Failed overriding client to server COMP method");
 			}
 			if (php_ssh2_set_method(session, HASH_OF(container), "lang", sizeof("lang") - 1, LIBSSH2_METHOD_LANG_CS)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding client to server LANG method");
+				php_error_docref(NULL, E_WARNING, "Failed overriding client to server LANG method");
 			}
 		}
 		zend_string_release(hash_lookup_zstring);
@@ -353,16 +353,16 @@ LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, z
 		hash_lookup_zstring = zend_string_init("server_to_client", sizeof("server_to_client") - 1, 0);
 		if ((container = zend_hash_find(HASH_OF(methods), hash_lookup_zstring)) != NULL && Z_TYPE_P(container) == IS_ARRAY) {
 			if (php_ssh2_set_method(session, HASH_OF(container), "crypt", sizeof("crypt") - 1, LIBSSH2_METHOD_CRYPT_SC)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding server to client CRYPT method");
+				php_error_docref(NULL, E_WARNING, "Failed overriding server to client CRYPT method");
 			}
 			if (php_ssh2_set_method(session, HASH_OF(container), "mac", sizeof("mac") - 1, LIBSSH2_METHOD_MAC_SC)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding server to client MAC method");
+				php_error_docref(NULL, E_WARNING, "Failed overriding server to client MAC method");
 			}
 			if (php_ssh2_set_method(session, HASH_OF(container), "comp", sizeof("comp") - 1, LIBSSH2_METHOD_COMP_SC)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding server to client COMP method");
+				php_error_docref(NULL, E_WARNING, "Failed overriding server to client COMP method");
 			}
 			if (php_ssh2_set_method(session, HASH_OF(container), "lang", sizeof("lang") - 1, LIBSSH2_METHOD_LANG_SC)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed overriding server to client LANG method");
+				php_error_docref(NULL, E_WARNING, "Failed overriding server to client LANG method");
 			}
 		}
 		zend_string_release(hash_lookup_zstring);
@@ -373,20 +373,20 @@ LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, z
 	if (callbacks) {
 		/* ignore debug disconnect macerror */
 
-		if (php_ssh2_set_callback(session, HASH_OF(callbacks), "ignore", sizeof("ignore") - 1, LIBSSH2_CALLBACK_IGNORE, data TSRMLS_CC)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed setting IGNORE callback");
+		if (php_ssh2_set_callback(session, HASH_OF(callbacks), "ignore", sizeof("ignore") - 1, LIBSSH2_CALLBACK_IGNORE, data)) {
+			php_error_docref(NULL, E_WARNING, "Failed setting IGNORE callback");
 		}
 
-		if (php_ssh2_set_callback(session, HASH_OF(callbacks), "debug", sizeof("debug") - 1, LIBSSH2_CALLBACK_DEBUG, data TSRMLS_CC)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed setting DEBUG callback");
+		if (php_ssh2_set_callback(session, HASH_OF(callbacks), "debug", sizeof("debug") - 1, LIBSSH2_CALLBACK_DEBUG, data)) {
+			php_error_docref(NULL, E_WARNING, "Failed setting DEBUG callback");
 		}
 
-		if (php_ssh2_set_callback(session, HASH_OF(callbacks), "macerror", sizeof("macerror") - 1, LIBSSH2_CALLBACK_MACERROR, data TSRMLS_CC)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed setting MACERROR callback");
+		if (php_ssh2_set_callback(session, HASH_OF(callbacks), "macerror", sizeof("macerror") - 1, LIBSSH2_CALLBACK_MACERROR, data)) {
+			php_error_docref(NULL, E_WARNING, "Failed setting MACERROR callback");
 		}
 
-		if (php_ssh2_set_callback(session, HASH_OF(callbacks), "disconnect", sizeof("disconnect") - 1, LIBSSH2_CALLBACK_DISCONNECT, data TSRMLS_CC)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed setting DISCONNECT callback");
+		if (php_ssh2_set_callback(session, HASH_OF(callbacks), "disconnect", sizeof("disconnect") - 1, LIBSSH2_CALLBACK_DISCONNECT, data)) {
+			php_error_docref(NULL, E_WARNING, "Failed setting DISCONNECT callback");
 		}
 	}
 
@@ -395,7 +395,7 @@ LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, z
 		char *error_msg = NULL;
 
 		last_error = libssh2_session_last_error(session, &error_msg, NULL, 0);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error starting up SSH connection(%d): %s", last_error, error_msg);
+		php_error_docref(NULL, E_WARNING, "Error starting up SSH connection(%d): %s", last_error, error_msg);
 		closesocket(socket);
 		libssh2_session_free(session);
 		efree(data);
@@ -417,13 +417,13 @@ PHP_FUNCTION(ssh2_connect)
 	zend_long port = PHP_SSH2_DEFAULT_PORT;
 	size_t host_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|la!a!", &host, &host_len, &port, &methods, &callbacks) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|la!a!", &host, &host_len, &port, &methods, &callbacks) == FAILURE) {
 		return;
 	}
 
-	session = php_ssh2_session_connect(host, port, methods, callbacks TSRMLS_CC);
+	session = php_ssh2_session_connect(host, port, methods, callbacks);
 	if (!session) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to connect to %s", host);
+		php_error_docref(NULL, E_WARNING, "Unable to connect to %s", host);
 		RETURN_FALSE;
 	}
 
@@ -438,7 +438,7 @@ PHP_FUNCTION(ssh2_disconnect)
 {
 	zval *zsession;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zsession) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zsession) == FAILURE) {
 		RETURN_FALSE;
 	}
 
@@ -459,7 +459,7 @@ PHP_FUNCTION(ssh2_methods_negotiated)
 	zval *zsession, endpoint;
 	char *kex, *hostkey, *crypt_cs, *crypt_sc, *mac_cs, *mac_sc, *comp_cs, *comp_sc, *lang_cs, *lang_sc;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zsession) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zsession) == FAILURE) {
 		return;
 	}
 
@@ -510,7 +510,7 @@ PHP_FUNCTION(ssh2_fingerprint)
 	zend_long flags = 0;
 	int i, fingerprint_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|l", &zsession, &flags) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|l", &zsession, &flags) == FAILURE) {
 		return;
 	}
 	fingerprint_len = (flags & PHP_SSH2_FINGERPRINT_SHA1) ? SHA_DIGEST_LENGTH : MD5_DIGEST_LENGTH;
@@ -521,7 +521,7 @@ PHP_FUNCTION(ssh2_fingerprint)
 
 	fingerprint = (char*)libssh2_hostkey_hash(session, (flags & PHP_SSH2_FINGERPRINT_SHA1) ? LIBSSH2_HOSTKEY_HASH_SHA1 : LIBSSH2_HOSTKEY_HASH_MD5);
 	if (!fingerprint) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to retrieve fingerprint from specified session");
+		php_error_docref(NULL, E_WARNING, "Unable to retrieve fingerprint from specified session");
 		RETURN_FALSE;
 	}
 
@@ -530,7 +530,7 @@ PHP_FUNCTION(ssh2_fingerprint)
 			goto fingerprint_good;
 		}
 	}
-	php_error_docref(NULL TSRMLS_CC, E_WARNING, "No fingerprint available using specified hash");
+	php_error_docref(NULL, E_WARNING, "No fingerprint available using specified hash");
 	RETURN_NULL();
  fingerprint_good:
 	if (flags & PHP_SSH2_FINGERPRINT_RAW) {
@@ -559,7 +559,7 @@ PHP_FUNCTION(ssh2_auth_none)
 	char *username, *methods, *s, *p;
 	size_t username_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &zsession, &username, &username_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &zsession, &username, &username_len) == FAILURE) {
 		return;
 	}
 
@@ -617,7 +617,7 @@ PHP_FUNCTION(ssh2_auth_password)
 	zend_string *username, *password;
 	char *userauthlist;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rSS", &zsession, &username, &password) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rSS", &zsession, &username, &password) == FAILURE) {
 		return;
 	}
 
@@ -635,7 +635,7 @@ PHP_FUNCTION(ssh2_auth_password)
 
 		/* TODO: Support password change callback */
 		if (libssh2_userauth_password_ex(session, username->val, username->len, password->val, password->len, NULL)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Authentication failed for %s using password", username->val);
+			php_error_docref(NULL, E_WARNING, "Authentication failed for %s using password", username->val);
 			RETURN_FALSE;
 		}
 	}
@@ -658,7 +658,7 @@ PHP_FUNCTION(ssh2_auth_pubkey_file)
 	struct passwd *pws;
 #endif
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rsss|s", &zsession,	&username, &username_len,
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsss|s", &zsession,	&username, &username_len,
 																				&pubkey, &pubkey_len,
 																				&privkey, &privkey_len,
 																				&passphrase, &passphrase_len) == FAILURE) {
@@ -695,7 +695,7 @@ PHP_FUNCTION(ssh2_auth_pubkey_file)
 		char *buf;
 		int len;
 		libssh2_session_last_error(session, &buf, &len, 0);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Authentication failed for %s using public key: %s", username, buf);
+		php_error_docref(NULL, E_WARNING, "Authentication failed for %s using public key: %s", username, buf);
 		RETURN_FALSE;
 	}
 
@@ -713,7 +713,7 @@ PHP_FUNCTION(ssh2_auth_hostbased_file)
 	char *username, *hostname, *pubkey, *privkey, *passphrase = NULL, *local_username = NULL;
 	size_t username_len, hostname_len, pubkey_len, privkey_len, passphrase_len, local_username_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rssss|s!s!", &zsession,	&username, &username_len,
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rssss|s!s!", &zsession,	&username, &username_len,
 																					&hostname, &hostname_len,
 																					&pubkey, &pubkey_len,
 																					&privkey, &privkey_len,
@@ -735,7 +735,7 @@ PHP_FUNCTION(ssh2_auth_hostbased_file)
 
 	/* TODO: Support passphrase callback */
 	if (libssh2_userauth_hostbased_fromfile_ex(session, username, username_len, pubkey, privkey, passphrase, hostname, hostname_len, local_username, local_username_len)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Authentication failed for %s using hostbased public key", username);
+		php_error_docref(NULL, E_WARNING, "Authentication failed for %s using hostbased public key", username);
 		RETURN_FALSE;
 	}
 
@@ -757,7 +757,7 @@ PHP_FUNCTION(ssh2_forward_listen)
 	size_t host_len;
 	zend_long max_connections = PHP_SSH2_LISTEN_MAX_QUEUED;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl|sl", &zsession, &port, &host, &host_len, &max_connections) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl|sl", &zsession, &port, &host, &host_len, &max_connections) == FAILURE) {
 		return;
 	}
 
@@ -766,7 +766,7 @@ PHP_FUNCTION(ssh2_forward_listen)
 	listener = libssh2_channel_forward_listen_ex(session, host, port, NULL, max_connections);
 
 	if (!listener) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure listening on remote port");
+		php_error_docref(NULL, E_WARNING, "Failure listening on remote port");
 		RETURN_FALSE;
 	}
 
@@ -792,7 +792,7 @@ PHP_FUNCTION(ssh2_forward_accept)
 	php_ssh2_channel_data *channel_data;
 	php_stream *stream;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zlistener) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zlistener) == FAILURE) {
 		return;
 	}
 
@@ -815,7 +815,7 @@ PHP_FUNCTION(ssh2_forward_accept)
 
 	stream = php_stream_alloc(&php_ssh2_channel_stream_ops, channel_data, 0, "r+");
 	if (!stream) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure allocating stream");
+		php_error_docref(NULL, E_WARNING, "Failure allocating stream");
 		efree(channel_data);
 		libssh2_channel_free(channel);
 		RETURN_FALSE;
@@ -850,7 +850,7 @@ PHP_FUNCTION(ssh2_poll)
 	int le_pstream = php_file_le_pstream();
 	zend_string *hash_key_zstring;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a|l", &zdesc, &timeout) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a|l", &zdesc, &timeout) == FAILURE) {
 		return;
 	}
 
@@ -866,14 +866,14 @@ PHP_FUNCTION(ssh2_poll)
 		void *res;
 
 		if (Z_TYPE_P(subarray) != IS_ARRAY) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid element in poll array, not a sub array");
+			php_error_docref(NULL, E_WARNING, "Invalid element in poll array, not a sub array");
 			numfds--;
 			continue;
 		}
 
 		hash_key_zstring = zend_string_init("events", sizeof("events") - 1, 0);
 		if ((tmpzval = zend_hash_find(Z_ARRVAL_P(subarray), hash_key_zstring)) == NULL || Z_TYPE_P(tmpzval) != IS_LONG) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid data in subarray, no events element, or not a bitmask");
+			php_error_docref(NULL, E_WARNING, "Invalid data in subarray, no events element, or not a bitmask");
 			numfds--;
 			zend_string_release(hash_key_zstring);
 			continue;
@@ -883,7 +883,7 @@ PHP_FUNCTION(ssh2_poll)
 		pollfds[i].events = Z_LVAL_P(tmpzval);
 		hash_key_zstring = zend_string_init("resource", sizeof("resource") - 1, 0);
 		if ((tmpzval = zend_hash_find(Z_ARRVAL_P(subarray), hash_key_zstring)) == NULL || Z_TYPE_P(tmpzval) != IS_RESOURCE) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid data in subarray, no resource element, or not of type resource");
+			php_error_docref(NULL, E_WARNING, "Invalid data in subarray, no resource element, or not of type resource");
 			numfds--;
 			zend_string_release(hash_key_zstring);
 			continue;
@@ -901,7 +901,7 @@ PHP_FUNCTION(ssh2_poll)
 			pollfds[i].fd.channel = ((php_ssh2_channel_data*)(((php_stream*)res)->abstract))->channel;
 			/* TODO: Add the ability to select against other stream types */
 		} else {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid resource type in subarray: %s", zend_rsrc_list_get_rsrc_type(Z_RES_P(tmpzval)));
+			php_error_docref(NULL, E_WARNING, "Invalid resource type in subarray: %s", zend_rsrc_list_get_rsrc_type(Z_RES_P(tmpzval)));
 			numfds--;
 			continue;
 		}
@@ -956,7 +956,7 @@ PHP_FUNCTION(ssh2_publickey_init)
 	LIBSSH2_PUBLICKEY *pkey;
 	php_ssh2_pkey_subsys_data *data;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zsession) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zsession) == FAILURE) {
 		return;
 	}
 
@@ -969,7 +969,7 @@ PHP_FUNCTION(ssh2_publickey_init)
 		char *error_msg = NULL;
 
 		last_error = libssh2_session_last_error(session, &error_msg, NULL, 0);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to initialize publickey subsystem(%d) %s", last_error, error_msg);
+		php_error_docref(NULL, E_WARNING, "Unable to initialize publickey subsystem(%d) %s", last_error, error_msg);
 		RETURN_FALSE;
 	}
 
@@ -996,7 +996,7 @@ PHP_FUNCTION(ssh2_publickey_add)
 	libssh2_publickey_attribute *attrs = NULL;
 	zend_bool overwrite = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rss|ba", &zpkey_data, &algo, &algo_len, &blob, &blob_len, &overwrite, &zattrs) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss|ba", &zpkey_data, &algo, &algo_len, &blob, &blob_len, &overwrite, &zattrs) == FAILURE) {
 		return;
 	}
 
@@ -1027,14 +1027,14 @@ PHP_FUNCTION(ssh2_publickey_add)
 			}
 			if (type == HASH_KEY_IS_LONG) {
 				/* Malformed, ignore */
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Malformed attirbute array, contains numeric index");
+				php_error_docref(NULL, E_WARNING, "Malformed attirbute array, contains numeric index");
 				num_attrs--;
 				continue;
 			}
 
 			if (!key || (key->len == 1 && key->val[0] == '*')) {
 				/* Empty key, ignore */
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Empty attribute key");
+				php_error_docref(NULL, E_WARNING, "Empty attribute key");
 				num_attrs--;
 				continue;
 			}
@@ -1063,7 +1063,7 @@ PHP_FUNCTION(ssh2_publickey_add)
 	}
 
 	if (libssh2_publickey_add_ex(data->pkey, (unsigned char *) algo, algo_len, (unsigned char *) blob, blob_len, overwrite, num_attrs, attrs)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to add %s key", algo);
+		php_error_docref(NULL, E_WARNING, "Unable to add %s key", algo);
 		RETVAL_FALSE;
 	} else {
 		RETVAL_TRUE;
@@ -1091,7 +1091,7 @@ PHP_FUNCTION(ssh2_publickey_remove)
 	char *algo, *blob;
 	size_t algo_len, blob_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rss", &zpkey_data, &algo, &algo_len, &blob, &blob_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss", &zpkey_data, &algo, &algo_len, &blob, &blob_len) == FAILURE) {
 		return;
 	}
 
@@ -1100,7 +1100,7 @@ PHP_FUNCTION(ssh2_publickey_remove)
 	}
 
 	if (libssh2_publickey_remove_ex(data->pkey, (unsigned char *) algo, algo_len, (unsigned char *) blob, blob_len)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to remove %s key", algo);
+		php_error_docref(NULL, E_WARNING, "Unable to remove %s key", algo);
 		RETURN_FALSE;
 	}
 
@@ -1118,7 +1118,7 @@ PHP_FUNCTION(ssh2_publickey_list)
 	libssh2_publickey_list *keys;
 	zend_string *hash_key_zstring;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zpkey_data) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zpkey_data) == FAILURE) {
 		return;
 	}
 
@@ -1127,7 +1127,7 @@ PHP_FUNCTION(ssh2_publickey_list)
 	}
 
 	if (libssh2_publickey_list_fetch(data->pkey, &num_keys, &keys)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to list keys on remote server");
+		php_error_docref(NULL, E_WARNING, "Unable to list keys on remote server");
 		RETURN_FALSE;
 	}
 
@@ -1174,7 +1174,7 @@ PHP_FUNCTION(ssh2_auth_agent)
 	int rc;
 	struct libssh2_agent_publickey *identity, *prev_identity = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &zsession, &username, &username_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &zsession, &username, &username_len) == FAILURE) {
 		return;
 	}
 
@@ -1184,7 +1184,7 @@ PHP_FUNCTION(ssh2_auth_agent)
 	userauthlist = libssh2_userauth_list(session, username, username_len);
 
 	if (userauthlist != NULL && strstr(userauthlist, "publickey") == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "\"publickey\" authentication is not supported");
+		php_error_docref(NULL, E_WARNING, "\"publickey\" authentication is not supported");
 		RETURN_FALSE;
 	}
 
@@ -1192,18 +1192,18 @@ PHP_FUNCTION(ssh2_auth_agent)
 	agent = libssh2_agent_init(session);
 
 	if (!agent) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure initializing ssh-agent support");
+		php_error_docref(NULL, E_WARNING, "Failure initializing ssh-agent support");
 		RETURN_FALSE;
 	}
 
 	if (libssh2_agent_connect(agent)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure connecting to ssh-agent");
+		php_error_docref(NULL, E_WARNING, "Failure connecting to ssh-agent");
 		libssh2_agent_free(agent);
 		RETURN_FALSE;
 	}
 
 	if (libssh2_agent_list_identities(agent)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure requesting identities to ssh-agent");
+		php_error_docref(NULL, E_WARNING, "Failure requesting identities to ssh-agent");
 		libssh2_agent_disconnect(agent);
 		libssh2_agent_free(agent);
 		RETURN_FALSE;
@@ -1213,14 +1213,14 @@ PHP_FUNCTION(ssh2_auth_agent)
 		rc = libssh2_agent_get_identity(agent, &identity, prev_identity);
 
 		if (rc == 1) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Couldn't continue authentication");
+			php_error_docref(NULL, E_WARNING, "Couldn't continue authentication");
 			libssh2_agent_disconnect(agent);
 			libssh2_agent_free(agent);
 			RETURN_FALSE;
 		}
 
 		if (rc < 0) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure obtaining identity from ssh-agent support");
+			php_error_docref(NULL, E_WARNING, "Failure obtaining identity from ssh-agent support");
 			libssh2_agent_disconnect(agent);
 			libssh2_agent_free(agent);
 			RETURN_FALSE;
@@ -1234,7 +1234,7 @@ PHP_FUNCTION(ssh2_auth_agent)
 		prev_identity = identity;
 	}
 #else
-	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Upgrade the libssh2 library (needs 1.2.3 or higher) and reinstall the ssh2 extension for ssh2 agent support");
+	php_error_docref(NULL, E_WARNING, "Upgrade the libssh2 library (needs 1.2.3 or higher) and reinstall the ssh2 extension for ssh2 agent support");
 	RETURN_FALSE;
 #endif /* PHP_SSH2_AGENT_AUTH */
 }
@@ -1244,7 +1244,7 @@ PHP_FUNCTION(ssh2_auth_agent)
    * Module Housekeeping *
    *********************** */
 
-static void php_ssh2_session_dtor(zend_resource *rsrc TSRMLS_DC)
+static void php_ssh2_session_dtor(zend_resource *rsrc)
 {
 	LIBSSH2_SESSION *session = (LIBSSH2_SESSION*)rsrc->ptr;
 	php_ssh2_session_data **data = (php_ssh2_session_data**)libssh2_session_abstract(session);
@@ -1274,7 +1274,7 @@ static void php_ssh2_session_dtor(zend_resource *rsrc TSRMLS_DC)
 	libssh2_session_free(session);
 }
 
-static void php_ssh2_listener_dtor(zend_resource *rsrc TSRMLS_DC)
+static void php_ssh2_listener_dtor(zend_resource *rsrc)
 {
 	php_ssh2_listener_data *data = (php_ssh2_listener_data*)rsrc->ptr;
 	LIBSSH2_LISTENER *listener = data->listener;
@@ -1285,7 +1285,7 @@ static void php_ssh2_listener_dtor(zend_resource *rsrc TSRMLS_DC)
 	efree(data);
 }
 
-static void php_ssh2_pkey_subsys_dtor(zend_resource *rsrc TSRMLS_DC)
+static void php_ssh2_pkey_subsys_dtor(zend_resource *rsrc)
 {
 	php_ssh2_pkey_subsys_data *data = (php_ssh2_pkey_subsys_data*)rsrc->ptr;
 	LIBSSH2_PUBLICKEY *pkey = data->pkey;
@@ -1334,11 +1334,11 @@ PHP_MINIT_FUNCTION(ssh2)
 	REGISTER_LONG_CONSTANT("SSH2_POLL_CHANNEL_CLOSED",	LIBSSH2_POLLFD_CHANNEL_CLOSED,	CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("SSH2_POLL_LISTENER_CLOSED",	LIBSSH2_POLLFD_LISTENER_CLOSED,	CONST_CS | CONST_PERSISTENT);
 
-	return (php_register_url_stream_wrapper("ssh2.shell", &php_ssh2_stream_wrapper_shell TSRMLS_CC) == SUCCESS &&
-			php_register_url_stream_wrapper("ssh2.exec", &php_ssh2_stream_wrapper_exec TSRMLS_CC) == SUCCESS &&
-			php_register_url_stream_wrapper("ssh2.tunnel", &php_ssh2_stream_wrapper_tunnel TSRMLS_CC) == SUCCESS &&
-			php_register_url_stream_wrapper("ssh2.scp", &php_ssh2_stream_wrapper_scp TSRMLS_CC) == SUCCESS &&
-			php_register_url_stream_wrapper("ssh2.sftp", &php_ssh2_sftp_wrapper TSRMLS_CC) == SUCCESS) ? SUCCESS : FAILURE;
+	return (php_register_url_stream_wrapper("ssh2.shell", &php_ssh2_stream_wrapper_shell) == SUCCESS &&
+			php_register_url_stream_wrapper("ssh2.exec", &php_ssh2_stream_wrapper_exec) == SUCCESS &&
+			php_register_url_stream_wrapper("ssh2.tunnel", &php_ssh2_stream_wrapper_tunnel) == SUCCESS &&
+			php_register_url_stream_wrapper("ssh2.scp", &php_ssh2_stream_wrapper_scp) == SUCCESS &&
+			php_register_url_stream_wrapper("ssh2.sftp", &php_ssh2_sftp_wrapper) == SUCCESS) ? SUCCESS : FAILURE;
 }
 /* }}} */
 
@@ -1346,11 +1346,11 @@ PHP_MINIT_FUNCTION(ssh2)
  */
 PHP_MSHUTDOWN_FUNCTION(ssh2)
 {
-	return (php_unregister_url_stream_wrapper("ssh2.shell" TSRMLS_CC) == SUCCESS &&
-			php_unregister_url_stream_wrapper("ssh2.exec" TSRMLS_CC) == SUCCESS &&
-			php_unregister_url_stream_wrapper("ssh2.tunnel" TSRMLS_CC) == SUCCESS &&
-			php_unregister_url_stream_wrapper("ssh2.scp" TSRMLS_CC) == SUCCESS &&
-			php_unregister_url_stream_wrapper("ssh2.sftp" TSRMLS_CC) == SUCCESS) ? SUCCESS : FAILURE;
+	return (php_unregister_url_stream_wrapper("ssh2.shell") == SUCCESS &&
+			php_unregister_url_stream_wrapper("ssh2.exec") == SUCCESS &&
+			php_unregister_url_stream_wrapper("ssh2.tunnel") == SUCCESS &&
+			php_unregister_url_stream_wrapper("ssh2.scp") == SUCCESS &&
+			php_unregister_url_stream_wrapper("ssh2.sftp") == SUCCESS) ? SUCCESS : FAILURE;
 }
 /* }}} */
 

--- a/ssh2.c
+++ b/ssh2.c
@@ -897,7 +897,7 @@ PHP_FUNCTION(ssh2_poll)
 			pollfds[i].type = LIBSSH2_POLLFD_LISTENER;
 			pollfds[i].fd.listener = ((php_ssh2_listener_data*)res)->listener;
 		} else if ((res_type == le_stream || res_type == le_pstream) &&
-				   ((php_stream*)res)->ops == &php_ssh2_channel_stream_ops) {
+								((php_stream*)res)->ops == &php_ssh2_channel_stream_ops) {
 			pollfds[i].type = LIBSSH2_POLLFD_CHANNEL;
 			pollfds[i].fd.channel = ((php_ssh2_channel_data*)(((php_stream*)res)->abstract))->channel;
 			/* TODO: Add the ability to select against other stream types */

--- a/ssh2.c
+++ b/ssh2.c
@@ -665,7 +665,7 @@ PHP_FUNCTION(ssh2_auth_pubkey_file)
 		return;
 	}
 
-	if (SSH2_OPENBASEDIR_CHECKPATH(pubkey) || SSH2_OPENBASEDIR_CHECKPATH(privkey)) {
+	if (php_check_open_basedir(pubkey) || php_check_open_basedir(privkey)) {
 		RETURN_FALSE;
 	}
 
@@ -722,7 +722,7 @@ PHP_FUNCTION(ssh2_auth_hostbased_file)
 		return;
 	}
 
-	if (SSH2_OPENBASEDIR_CHECKPATH(pubkey) || SSH2_OPENBASEDIR_CHECKPATH(privkey)) {
+	if (php_check_open_basedir(pubkey) || php_check_open_basedir(privkey)) {
 		RETURN_FALSE;
 	}
 
@@ -1603,9 +1603,7 @@ zend_function_entry ssh2_functions[] = {
 /* {{{ ssh2_module_entry
  */
 zend_module_entry ssh2_module_entry = {
-#if ZEND_MODULE_API_NO >= 20010901
 	STANDARD_MODULE_HEADER,
-#endif
 	"ssh2",
 	ssh2_functions,
 	PHP_MINIT(ssh2),
@@ -1613,9 +1611,7 @@ zend_module_entry ssh2_module_entry = {
 	NULL, /* RINIT */
 	NULL, /* RSHUTDOWN */
 	PHP_MINFO(ssh2),
-#if ZEND_MODULE_API_NO >= 20010901
 	PHP_SSH2_VERSION,
-#endif
 	STANDARD_MODULE_PROPERTIES
 };
 /* }}} */

--- a/ssh2.c
+++ b/ssh2.c
@@ -1,22 +1,22 @@
 /*
-  +----------------------------------------------------------------------+
-  | PHP Version 4                                                        |
-  +----------------------------------------------------------------------+
-  | Copyright (c) 1997-2006 The PHP Group                                |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.01 of the PHP license,      |
-  | that is bundled with this package in the file LICENSE, and is        |
-  | available at through the world-wide-web at                           |
-  | http://www.php.net/license/3_01.txt.                                 |
-  | If you did not receive a copy of the PHP license and are unable to   |
-  | obtain it through the world-wide-web, please send a note to          |
-  | license@php.net so we can mail you a copy immediately.               |
-  +----------------------------------------------------------------------+
-  | Author: Sara Golemon <pollita@php.net>                               |
-  +----------------------------------------------------------------------+
-
-  $Id$
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2016 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author: Sara Golemon <pollita@php.net>                               |
+   +----------------------------------------------------------------------+
 */
+
+/* $Id$ */
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -469,7 +469,7 @@ session_authed:
 		sftp_data->session_rsrcid = Z_LVAL(zsession);
 
 		//TODO Sean-Der
-		//ZEND_REGISTER_RESOURCE(sftp_data, le_ssh2_sftp);
+		//ZEND_REGISTER_RESOURCE(&zsftp, sftp_data, le_ssh2_sftp);
 		*psftp_rsrcid = Z_LVAL(zsftp);
 		*psftp = sftp;
 	}
@@ -1135,8 +1135,10 @@ PHP_FUNCTION(ssh2_scp_send)
 
 	remote_file = libssh2_scp_send_ex(session, remote_filename, create_mode, ssb.sb.st_size, ssb.sb.st_atime, ssb.sb.st_mtime);
 	if (!remote_file) {
+		//int last_error = 0;
 		char *error_msg = NULL;
 
+		//last_error = libssh2_session_last_error(session, &error_msg, NULL, 0);
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure creating remote file: %s", error_msg);
 		php_stream_close(local_file);
 		RETURN_FALSE;

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -1135,10 +1135,10 @@ PHP_FUNCTION(ssh2_scp_send)
 
 	remote_file = libssh2_scp_send_ex(session, remote_filename, create_mode, ssb.sb.st_size, ssb.sb.st_atime, ssb.sb.st_mtime);
 	if (!remote_file) {
-		//int last_error = 0;
+		int last_error = 0;
 		char *error_msg = NULL;
 
-		//last_error = libssh2_session_last_error(session, &error_msg, NULL, 0);
+		last_error = libssh2_session_last_error(session, &error_msg, NULL, 0);
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure creating remote file: %s", error_msg);
 		php_stream_close(local_file);
 		RETURN_FALSE;

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -442,8 +442,6 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 
 	/* Auth failure */
 	php_url_free(resource);
-	//TODO Sean-Der
-	//zend_list_delete(Z_LVAL(zsession));
 	return NULL;
 
 session_authed:

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -1,22 +1,22 @@
 /*
-  +----------------------------------------------------------------------+
-  | PHP Version 4                                                        |
-  +----------------------------------------------------------------------+
-  | Copyright (c) 1997-2006 The PHP Group                                |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.01 of the PHP license,      |
-  | that is bundled with this package in the file LICENSE, and is        |
-  | available at through the world-wide-web at                           |
-  | http://www.php.net/license/3_01.txt.                                 |
-  | If you did not receive a copy of the PHP license and are unable to   |
-  | obtain it through the world-wide-web, please send a note to          |
-  | license@php.net so we can mail you a copy immediately.               |
-  +----------------------------------------------------------------------+
-  | Author: Sara Golemon <pollita@php.net>                               |
-  +----------------------------------------------------------------------+
-
-  $Id$
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2016 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author: Sara Golemon <pollita@php.net>                               |
+   +----------------------------------------------------------------------+
 */
+
+/* $Id$ */
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -176,11 +176,9 @@ static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, in
 			return ret;
 			break;
 
-#if PHP_MAJOR_VERSION >= 5
 		case PHP_STREAM_OPTION_CHECK_LIVENESS:
 			return stream->eof = libssh2_channel_eof(abstract->channel);
 			break;
-#endif
 	}
 
 	return -1;
@@ -425,7 +423,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 
 	/* Authenticate */
 	if (pubkey_file && privkey_file) {
-		if (SSH2_OPENBASEDIR_CHECKPATH(pubkey_file) || SSH2_OPENBASEDIR_CHECKPATH(privkey_file)) {
+		if (php_check_open_basedir(pubkey_file) || php_check_open_basedir(privkey_file)) {
 			php_url_free(resource);
 			return NULL;
 		}

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -676,7 +676,7 @@ static php_stream_wrapper_ops php_ssh2_shell_stream_wops = {
 	"ssh2.shell"
 };
 
-php_stream_wrapper php_ssh2_stream_wrapper_shell =    {
+php_stream_wrapper php_ssh2_stream_wrapper_shell = {
 	&php_ssh2_shell_stream_wops,
 	NULL,
 	0
@@ -1054,7 +1054,7 @@ PHP_FUNCTION(ssh2_scp_recv)
 	char *remote_filename, *local_filename;
 	size_t remote_filename_len, local_filename_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rss", &zsession,  &remote_filename, &remote_filename_len,
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rss", &zsession, &remote_filename, &remote_filename_len,
 																			&local_filename, &local_filename_len) == FAILURE) {
 		return;
 	}
@@ -1113,7 +1113,7 @@ PHP_FUNCTION(ssh2_scp_send)
 	int argc = ZEND_NUM_ARGS();
 
 	if (zend_parse_parameters(argc TSRMLS_CC, "rss|l", &zsession, &local_filename, &local_filename_len,
-													   &remote_filename, &remote_filename_len, &create_mode) == FAILURE) {
+														&remote_filename, &remote_filename_len, &create_mode) == FAILURE) {
 		return;
 	}
 
@@ -1214,7 +1214,7 @@ static php_stream *php_ssh2_direct_tcpip(LIBSSH2_SESSION *session, int resource_
 	php_ssh2_channel_data *channel_data;
 	php_stream *stream;
 
-   	libssh2_session_set_blocking(session, 1);
+	libssh2_session_set_blocking(session, 1);
 
 	channel = libssh2_channel_direct_tcpip(session, host, port);
 	if (!channel) {
@@ -1305,7 +1305,7 @@ static php_stream_wrapper_ops php_ssh2_tunnel_stream_wops = {
 	"ssh2.tunnel"
 };
 
-php_stream_wrapper php_ssh2_stream_wrapper_tunnel =    {
+php_stream_wrapper php_ssh2_stream_wrapper_tunnel = {
 	&php_ssh2_tunnel_stream_wops,
 	NULL,
 	0

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -41,7 +41,7 @@ void *php_ssh2_zval_from_resource_handle(int handle) {
    * channel_stream_ops *
    ********************** */
 
-static size_t php_ssh2_channel_stream_write(php_stream *stream, const char *buf, size_t count TSRMLS_DC)
+static size_t php_ssh2_channel_stream_write(php_stream *stream, const char *buf, size_t count)
 {
 	php_ssh2_channel_data *abstract = (php_ssh2_channel_data*)stream->abstract;
 	size_t writestate;
@@ -72,7 +72,7 @@ static size_t php_ssh2_channel_stream_write(php_stream *stream, const char *buf,
 	if (writestate < 0) {
 		char *error_msg = NULL;
 		if (libssh2_session_last_error(session, &error_msg, NULL, 0) == writestate) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure '%s' (%ld)", error_msg, writestate);
+			php_error_docref(NULL, E_WARNING, "Failure '%s' (%ld)", error_msg, writestate);
 		}
 
 		stream->eof = 1;
@@ -82,7 +82,7 @@ static size_t php_ssh2_channel_stream_write(php_stream *stream, const char *buf,
 	return writestate;
 }
 
-static size_t php_ssh2_channel_stream_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
+static size_t php_ssh2_channel_stream_read(php_stream *stream, char *buf, size_t count)
 {
 	php_ssh2_channel_data *abstract = (php_ssh2_channel_data*)stream->abstract;
 	ssize_t readstate;
@@ -114,7 +114,7 @@ static size_t php_ssh2_channel_stream_read(php_stream *stream, char *buf, size_t
 	if (readstate < 0) {
 		char *error_msg = NULL;
 		if (libssh2_session_last_error(session, &error_msg, NULL, 0) == readstate) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure '%s' (%ld)", error_msg, readstate);
+			php_error_docref(NULL, E_WARNING, "Failure '%s' (%ld)", error_msg, readstate);
 		}
 
 		stream->eof = 1;
@@ -123,7 +123,7 @@ static size_t php_ssh2_channel_stream_read(php_stream *stream, char *buf, size_t
 	return readstate;
 }
 
-static int php_ssh2_channel_stream_close(php_stream *stream, int close_handle TSRMLS_DC)
+static int php_ssh2_channel_stream_close(php_stream *stream, int close_handle)
 {
 	php_ssh2_channel_data *abstract = (php_ssh2_channel_data*)stream->abstract;
 
@@ -142,14 +142,14 @@ static int php_ssh2_channel_stream_close(php_stream *stream, int close_handle TS
 	return 0;
 }
 
-static int php_ssh2_channel_stream_flush(php_stream *stream TSRMLS_DC)
+static int php_ssh2_channel_stream_flush(php_stream *stream)
 {
 	php_ssh2_channel_data *abstract = (php_ssh2_channel_data*)stream->abstract;
 
 	return libssh2_channel_flush_ex(abstract->channel, abstract->streamid);
 }
 
-static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, int value, void *ptrparam TSRMLS_DC)
+static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, int value, void *ptrparam)
 {
 	php_ssh2_channel_data *abstract = (php_ssh2_channel_data*)stream->abstract;
 	int ret;
@@ -171,7 +171,7 @@ static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, in
 			struct timeval tv = *(struct timeval*)ptrparam;
 			abstract->timeout = tv.tv_sec * 1000 + (tv.tv_usec / 1000);
 #else
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "No support for ssh2 stream timeout. Please recompile with libssh2 >= 1.2.9");
+			php_error_docref(NULL, E_WARNING, "No support for ssh2 stream timeout. Please recompile with libssh2 >= 1.2.9");
 #endif
 			return ret;
 			break;
@@ -205,8 +205,7 @@ php_stream_ops php_ssh2_channel_stream_ops = {
  */
 php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stream_context *context,
 											LIBSSH2_SESSION **psession, int *presource_id,
-											LIBSSH2_SFTP **psftp, int *psftp_rsrcid
-											TSRMLS_DC)
+											LIBSSH2_SFTP **psftp, int *psftp_rsrcid)
 {
 	php_ssh2_sftp_data *sftp_data = NULL;
 	LIBSSH2_SESSION *session;
@@ -305,7 +304,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 		(tmpzval = php_stream_context_get_option(context, "ssh2", "sftp")) != NULL &&
 		Z_TYPE_P(tmpzval) == IS_RESOURCE) {
 		php_ssh2_sftp_data *sftp_data;
-		sftp_data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(tmpzval) TSRMLS_CC, PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp);
+		sftp_data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(tmpzval), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp);
 		if (sftp_data) {
 			Z_ADDREF_P(tmpzval);
 			*psftp_rsrcid = Z_LVAL_P(tmpzval);
@@ -318,7 +317,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 	if (resource->host[0] == 0 && context &&
 		(tmpzval = php_stream_context_get_option(context, "ssh2", "session")) != NULL &&
 		Z_TYPE_P(tmpzval) == IS_RESOURCE) {
-		session = (LIBSSH2_SESSION *)zend_fetch_resource(Z_RES_P(tmpzval) TSRMLS_CC, PHP_SSH2_SESSION_RES_NAME, le_ssh2_session);
+		session = (LIBSSH2_SESSION *)zend_fetch_resource(Z_RES_P(tmpzval), PHP_SSH2_SESSION_RES_NAME, le_ssh2_session);
 		if (session) {
 			if (psftp) {
 				/* We need an SFTP layer too! */
@@ -414,7 +413,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 		return NULL;
 	}
 
-	session = php_ssh2_session_connect(resource->host, resource->port, methods, callbacks TSRMLS_CC);
+	session = php_ssh2_session_connect(resource->host, resource->port, methods, callbacks);
 	if (!session) {
 		/* Unable to connect! */
 		php_url_free(resource);
@@ -488,7 +487,7 @@ session_authed:
 /* {{{ php_ssh2_shell_open
  * Make a stream from a session
  */
-static php_stream *php_ssh2_shell_open(LIBSSH2_SESSION *session, int resource_id, char *term, int term_len, zval *environment, long width, long height, long type TSRMLS_DC)
+static php_stream *php_ssh2_shell_open(LIBSSH2_SESSION *session, int resource_id, char *term, int term_len, zval *environment, long width, long height, long type)
 {
 	LIBSSH2_CHANNEL *channel;
 	php_ssh2_channel_data *channel_data;
@@ -498,7 +497,7 @@ static php_stream *php_ssh2_shell_open(LIBSSH2_SESSION *session, int resource_id
 
 	channel = libssh2_channel_open_session(session);
 	if (!channel) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to request a channel from remote host");
+		php_error_docref(NULL, E_WARNING, "Unable to request a channel from remote host");
 		return NULL;
 	}
 
@@ -519,32 +518,32 @@ static php_stream *php_ssh2_shell_open(LIBSSH2_SESSION *session, int resource_id
 					zval_copy_ctor(&copyval);
 					convert_to_string(&copyval);
 					if (libssh2_channel_setenv_ex(channel, key->val, key->len, Z_STRVAL(copyval), Z_STRLEN(copyval))) {
-						php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed setting %s=%s on remote end", key, Z_STRVAL(copyval));
+						php_error_docref(NULL, E_WARNING, "Failed setting %s=%s on remote end", key, Z_STRVAL(copyval));
 					}
 					zval_dtor(&copyval);
 				}
 			} else {
-				php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Skipping numeric index in environment array");
+				php_error_docref(NULL, E_NOTICE, "Skipping numeric index in environment array");
 			}
 		}
 	}
 
 	if (type == PHP_SSH2_TERM_UNIT_CHARS) {
 		if (libssh2_channel_request_pty_ex(channel, term, term_len, NULL, 0, width, height, 0, 0)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed allocating %s pty at %ldx%ld characters", term, width, height);
+			php_error_docref(NULL, E_WARNING, "Failed allocating %s pty at %ldx%ld characters", term, width, height);
 			libssh2_channel_free(channel);
 			return NULL;
 		}
 	} else {
 		if (libssh2_channel_request_pty_ex(channel, term, term_len, NULL, 0, 0, 0, width, height)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed allocating %s pty at %ldx%ld pixels", term, width, height);
+			php_error_docref(NULL, E_WARNING, "Failed allocating %s pty at %ldx%ld pixels", term, width, height);
 			libssh2_channel_free(channel);
 			return NULL;
 		}
 	}
 
 	if (libssh2_channel_shell(channel)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to request shell from remote host");
+		php_error_docref(NULL, E_WARNING, "Unable to request shell from remote host");
 		libssh2_channel_free(channel);
 		return NULL;
 	}
@@ -567,7 +566,7 @@ static php_stream *php_ssh2_shell_open(LIBSSH2_SESSION *session, int resource_id
 /* {{{ php_ssh2_fopen_wrapper_shell
  * ssh2.shell:// fopen wrapper
  */
-static php_stream *php_ssh2_fopen_wrapper_shell(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC TSRMLS_DC)
+static php_stream *php_ssh2_fopen_wrapper_shell(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC)
 {
 	LIBSSH2_SESSION *session = NULL;
 	php_stream *stream;
@@ -580,7 +579,7 @@ static php_stream *php_ssh2_fopen_wrapper_shell(php_stream_wrapper *wrapper, con
 	php_url *resource;
 	char *s;
 
-	resource = php_ssh2_fopen_wraper_parse_path(path, "shell", context, &session, &resource_id, NULL, NULL TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(path, "shell", context, &session, &resource_id, NULL, NULL);
 	if (!resource || !session) {
 		return NULL;
 	}
@@ -654,7 +653,7 @@ static php_stream *php_ssh2_fopen_wrapper_shell(php_stream_wrapper *wrapper, con
 	/* TODO: Accept resolution and environment vars as URL style parameters
 	 * ssh2.shell://hostorresource/terminal/99x99c?envvar=envval&envvar=envval....
 	 */
-	stream = php_ssh2_shell_open(session, resource_id, terminal, terminal_len, environment, width, height, type TSRMLS_CC);
+	stream = php_ssh2_shell_open(session, resource_id, terminal, terminal_len, environment, width, height, type);
 	if (!stream) {
 		//TODO Sean-Der
 		//zend_list_delete(resource_id);
@@ -697,17 +696,17 @@ PHP_FUNCTION(ssh2_shell)
 	int argc = ZEND_NUM_ARGS();
 
 	if (argc == 5) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "width specified without height parameter");
+		php_error_docref(NULL, E_ERROR, "width specified without height parameter");
 		RETURN_FALSE;
 	}
 
-	if (zend_parse_parameters(argc TSRMLS_CC, "r|sa!lll", &zsession, &term, &term_len, &environment, &width, &height, &type) == FAILURE) {
+	if (zend_parse_parameters(argc, "r|sa!lll", &zsession, &term, &term_len, &environment, &width, &height, &type) == FAILURE) {
 		return;
 	}
 
 	SSH2_FETCH_AUTHENTICATED_SESSION(session, zsession);
 
-	stream = php_ssh2_shell_open(session, Z_LVAL_P(zsession), term, term_len, environment, width, height, type TSRMLS_CC);
+	stream = php_ssh2_shell_open(session, Z_LVAL_P(zsession), term, term_len, environment, width, height, type);
 	if (!stream) {
 		RETURN_FALSE;
 	}
@@ -726,7 +725,7 @@ PHP_FUNCTION(ssh2_shell)
 /* {{{ php_ssh2_exec_command
  * Make a stream from a session
  */
-static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session, int resource_id, char *command, char *term, int term_len, zval *environment, long width, long height, long type TSRMLS_DC)
+static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session, int resource_id, char *command, char *term, int term_len, zval *environment, long width, long height, long type)
 {
 	LIBSSH2_CHANNEL *channel;
 	php_ssh2_channel_data *channel_data;
@@ -736,7 +735,7 @@ static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session, int resource_
 
 	channel = libssh2_channel_open_session(session);
 	if (!channel) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to request a channel from remote host");
+		php_error_docref(NULL, E_WARNING, "Unable to request a channel from remote host");
 		return NULL;
 	}
 
@@ -758,12 +757,12 @@ static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session, int resource_
 					zval_copy_ctor(&copyval);
 					convert_to_string(&copyval);
 					if (libssh2_channel_setenv_ex(channel, key->val, key->len, Z_STRVAL(copyval), Z_STRLEN(copyval))) {
-						php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed setting %s=%s on remote end", key, Z_STRVAL(copyval));
+						php_error_docref(NULL, E_WARNING, "Failed setting %s=%s on remote end", key, Z_STRVAL(copyval));
 					}
 					zval_dtor(&copyval);
 				}
 			} else {
-				php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Skipping numeric index in environment array");
+				php_error_docref(NULL, E_NOTICE, "Skipping numeric index in environment array");
 			}
 		}
 	}
@@ -771,13 +770,13 @@ static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session, int resource_
 	if (term) {
 		if (type == PHP_SSH2_TERM_UNIT_CHARS) {
 			if (libssh2_channel_request_pty_ex(channel, term, term_len, NULL, 0, width, height, 0, 0)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed allocating %s pty at %ldx%ld characters", term, width, height);
+				php_error_docref(NULL, E_WARNING, "Failed allocating %s pty at %ldx%ld characters", term, width, height);
 				libssh2_channel_free(channel);
 				return NULL;
 			}
 		} else {
 			if (libssh2_channel_request_pty_ex(channel, term, term_len, NULL, 0, 0, 0, width, height)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed allocating %s pty at %ldx%ld pixels", term, width, height);
+				php_error_docref(NULL, E_WARNING, "Failed allocating %s pty at %ldx%ld pixels", term, width, height);
 				libssh2_channel_free(channel);
 				return NULL;
 			}
@@ -785,7 +784,7 @@ static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session, int resource_
 	}
 
 	if (libssh2_channel_exec(channel, command)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to request command execution on remote host");
+		php_error_docref(NULL, E_WARNING, "Unable to request command execution on remote host");
 		libssh2_channel_free(channel);
 		return NULL;
 	}
@@ -808,7 +807,7 @@ static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session, int resource_
 /* {{{ php_ssh2_fopen_wrapper_exec
  * ssh2.exec:// fopen wrapper
  */
-static php_stream *php_ssh2_fopen_wrapper_exec(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC TSRMLS_DC)
+static php_stream *php_ssh2_fopen_wrapper_exec(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC)
 {
 	LIBSSH2_SESSION *session = NULL;
 	php_stream *stream;
@@ -821,7 +820,7 @@ static php_stream *php_ssh2_fopen_wrapper_exec(php_stream_wrapper *wrapper, cons
 	long height = PHP_SSH2_DEFAULT_TERM_HEIGHT;
 	long type = PHP_SSH2_DEFAULT_TERM_UNIT;
 
-	resource = php_ssh2_fopen_wraper_parse_path(path, "exec", context, &session, &resource_id, NULL, NULL TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(path, "exec", context, &session, &resource_id, NULL, NULL);
 	if (!resource || !session) {
 		return NULL;
 	}
@@ -870,7 +869,7 @@ static php_stream *php_ssh2_fopen_wrapper_exec(php_stream_wrapper *wrapper, cons
 		zval_ptr_dtor(copyval);
 	}
 
-	stream = php_ssh2_exec_command(session, resource_id, resource->path + 1, terminal, terminal_len, environment, width, height, type TSRMLS_CC);
+	stream = php_ssh2_exec_command(session, resource_id, resource->path + 1, terminal, terminal_len, environment, width, height, type);
 	if (!stream) {
 		// TODO Sean-Der
 		//zend_list_delete(resource_id);
@@ -916,7 +915,7 @@ PHP_FUNCTION(ssh2_exec)
 	char *term = NULL;
 	int term_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs|z!z!lll", &zsession, &command, &command_len, &zpty, &environment, &width, &height, &type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs|z!z!lll", &zsession, &command, &command_len, &zpty, &environment, &width, &height, &type) == FAILURE) {
 		return;
 	}
 
@@ -928,7 +927,7 @@ PHP_FUNCTION(ssh2_exec)
 	}
 
 	if (environment && Z_TYPE_P(environment) != IS_ARRAY) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "ssh2_exec() expects arg 4 to be of type array");
+		php_error_docref(NULL, E_WARNING, "ssh2_exec() expects arg 4 to be of type array");
 		RETURN_FALSE;
 	}
 
@@ -940,7 +939,7 @@ PHP_FUNCTION(ssh2_exec)
 
 	SSH2_FETCH_AUTHENTICATED_SESSION(session, zsession);
 
-	stream = php_ssh2_exec_command(session, Z_LVAL_P(zsession), command, term, term_len, environment, width, height, type TSRMLS_CC);
+	stream = php_ssh2_exec_command(session, Z_LVAL_P(zsession), command, term, term_len, environment, width, height, type);
 	if (!stream) {
 		RETURN_FALSE;
 	}
@@ -959,7 +958,7 @@ PHP_FUNCTION(ssh2_exec)
 /* {{{ php_ssh2_scp_xfer
  * Make a stream from a session
  */
-static php_stream *php_ssh2_scp_xfer(LIBSSH2_SESSION *session, int resource_id, char *filename TSRMLS_DC)
+static php_stream *php_ssh2_scp_xfer(LIBSSH2_SESSION *session, int resource_id, char *filename)
 {
 	LIBSSH2_CHANNEL *channel;
 	php_ssh2_channel_data *channel_data;
@@ -969,7 +968,7 @@ static php_stream *php_ssh2_scp_xfer(LIBSSH2_SESSION *session, int resource_id, 
 	if (!channel) {
 		char *error = "";
 		libssh2_session_last_error(session, &error, NULL, 0);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to request a channel from remote host: %s", error);
+		php_error_docref(NULL, E_WARNING, "Unable to request a channel from remote host: %s", error);
 		return NULL;
 	}
 
@@ -991,7 +990,7 @@ static php_stream *php_ssh2_scp_xfer(LIBSSH2_SESSION *session, int resource_id, 
 /* {{{ php_ssh2_fopen_wrapper_scp
  * ssh2.scp:// fopen wrapper (Read mode only, if you want to know why write mode isn't supported as a stream, take a look at the SCP protocol)
  */
-static php_stream *php_ssh2_fopen_wrapper_scp(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC TSRMLS_DC)
+static php_stream *php_ssh2_fopen_wrapper_scp(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC)
 {
 	LIBSSH2_SESSION *session = NULL;
 	php_stream *stream;
@@ -1002,7 +1001,7 @@ static php_stream *php_ssh2_fopen_wrapper_scp(php_stream_wrapper *wrapper, const
 		return NULL;
 	}
 
-	resource = php_ssh2_fopen_wraper_parse_path(path, "scp", context, &session, &resource_id, NULL, NULL TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(path, "scp", context, &session, &resource_id, NULL, NULL);
 	if (!resource || !session) {
 		return NULL;
 	}
@@ -1013,7 +1012,7 @@ static php_stream *php_ssh2_fopen_wrapper_scp(php_stream_wrapper *wrapper, const
 		return NULL;
 	}
 
-	stream = php_ssh2_scp_xfer(session, resource_id, resource->path TSRMLS_CC);
+	stream = php_ssh2_scp_xfer(session, resource_id, resource->path);
 	if (!stream) {
 		//TODO Sean-Der
 		//zend_list_delete(resource_id);
@@ -1052,7 +1051,7 @@ PHP_FUNCTION(ssh2_scp_recv)
 	char *remote_filename, *local_filename;
 	size_t remote_filename_len, local_filename_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rss", &zsession, &remote_filename, &remote_filename_len,
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rss", &zsession, &remote_filename, &remote_filename_len,
 																			&local_filename, &local_filename_len) == FAILURE) {
 		return;
 	}
@@ -1061,14 +1060,14 @@ PHP_FUNCTION(ssh2_scp_recv)
 
 	remote_file = libssh2_scp_recv(session, remote_filename, &sb);
 	if (!remote_file) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to receive remote file");
+		php_error_docref(NULL, E_WARNING, "Unable to receive remote file");
 		RETURN_FALSE;
 	}
 	libssh2_channel_set_blocking(remote_file, 1);
 
 	local_file = php_stream_open_wrapper(local_filename, "wb", REPORT_ERRORS, NULL);
 	if (!local_file) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to write to local file");
+		php_error_docref(NULL, E_WARNING, "Unable to write to local file");
 		libssh2_channel_free(remote_file);
 		RETURN_FALSE;
 	}
@@ -1079,7 +1078,7 @@ PHP_FUNCTION(ssh2_scp_recv)
 
 		bytes_read = libssh2_channel_read(remote_file, buffer, sb.st_size > 8192 ? 8192 : sb.st_size);
 		if (bytes_read < 0) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error reading from remote file");
+			php_error_docref(NULL, E_WARNING, "Error reading from remote file");
 			libssh2_channel_free(remote_file);
 			php_stream_close(local_file);
 			RETURN_FALSE;
@@ -1110,7 +1109,7 @@ PHP_FUNCTION(ssh2_scp_send)
 	php_stream_statbuf ssb;
 	int argc = ZEND_NUM_ARGS();
 
-	if (zend_parse_parameters(argc TSRMLS_CC, "rss|l", &zsession, &local_filename, &local_filename_len,
+	if (zend_parse_parameters(argc, "rss|l", &zsession, &local_filename, &local_filename_len,
 														&remote_filename, &remote_filename_len, &create_mode) == FAILURE) {
 		return;
 	}
@@ -1119,12 +1118,12 @@ PHP_FUNCTION(ssh2_scp_send)
 
 	local_file = php_stream_open_wrapper(local_filename, "rb", REPORT_ERRORS, NULL);
 	if (!local_file) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to read source file");
+		php_error_docref(NULL, E_WARNING, "Unable to read source file");
 		RETURN_FALSE;
 	}
 
 	if (php_stream_stat(local_file, &ssb)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed statting local file");
+		php_error_docref(NULL, E_WARNING, "Failed statting local file");
 		php_stream_close(local_file);
 		RETURN_FALSE;
 	}
@@ -1139,7 +1138,7 @@ PHP_FUNCTION(ssh2_scp_send)
 		char *error_msg = NULL;
 
 		last_error = libssh2_session_last_error(session, &error_msg, NULL, 0);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure creating remote file: %s", error_msg);
+		php_error_docref(NULL, E_WARNING, "Failure creating remote file: %s", error_msg);
 		php_stream_close(local_file);
 		RETURN_FALSE;
 	}
@@ -1153,7 +1152,7 @@ PHP_FUNCTION(ssh2_scp_send)
 		size_t justsent = 0;
 
 		if (bytesread <= 0 || bytesread > toread) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed copying file 2");
+			php_error_docref(NULL, E_WARNING, "Failed copying file 2");
 			php_stream_close(local_file);
 			libssh2_channel_free(remote_file);
 			RETURN_FALSE;
@@ -1165,23 +1164,23 @@ PHP_FUNCTION(ssh2_scp_send)
 
 				switch (justsent) {
 					case LIBSSH2_ERROR_EAGAIN:
-						php_error_docref(NULL TSRMLS_CC, E_WARNING, "Operation would block");
+						php_error_docref(NULL, E_WARNING, "Operation would block");
 						break;
 
 					case LIBSSH2_ERROR_ALLOC:
-						php_error_docref(NULL TSRMLS_CC,E_WARNING, "An internal memory allocation call failed");
+						php_error_docref(NULL,E_WARNING, "An internal memory allocation call failed");
 						break;
 
 					case LIBSSH2_ERROR_SOCKET_SEND:
-						php_error_docref(NULL TSRMLS_CC,E_WARNING, "Unable to send data on socket");
+						php_error_docref(NULL,E_WARNING, "Unable to send data on socket");
 						break;
 
 					case LIBSSH2_ERROR_CHANNEL_CLOSED:
-						php_error_docref(NULL TSRMLS_CC,E_WARNING, "The channel has been closed");
+						php_error_docref(NULL,E_WARNING, "The channel has been closed");
 						break;
 
 					case LIBSSH2_ERROR_CHANNEL_EOF_SENT:
-						php_error_docref(NULL TSRMLS_CC,E_WARNING, "The channel has been requested to be closed");
+						php_error_docref(NULL,E_WARNING, "The channel has been requested to be closed");
 						break;
 				}
 
@@ -1208,7 +1207,7 @@ PHP_FUNCTION(ssh2_scp_send)
 /* {{{ php_ssh2_direct_tcpip
  * Make a stream from a session
  */
-static php_stream *php_ssh2_direct_tcpip(LIBSSH2_SESSION *session, int resource_id, char *host, int port TSRMLS_DC)
+static php_stream *php_ssh2_direct_tcpip(LIBSSH2_SESSION *session, int resource_id, char *host, int port)
 {
 	LIBSSH2_CHANNEL *channel;
 	php_ssh2_channel_data *channel_data;
@@ -1218,7 +1217,7 @@ static php_stream *php_ssh2_direct_tcpip(LIBSSH2_SESSION *session, int resource_
 
 	channel = libssh2_channel_direct_tcpip(session, host, port);
 	if (!channel) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to request a channel from remote host");
+		php_error_docref(NULL, E_WARNING, "Unable to request a channel from remote host");
 		return NULL;
 	}
 
@@ -1240,7 +1239,7 @@ static php_stream *php_ssh2_direct_tcpip(LIBSSH2_SESSION *session, int resource_
 /* {{{ php_ssh2_fopen_wrapper_tunnel
  * ssh2.tunnel:// fopen wrapper
  */
-static php_stream *php_ssh2_fopen_wrapper_tunnel(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC TSRMLS_DC)
+static php_stream *php_ssh2_fopen_wrapper_tunnel(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC)
 {
 	LIBSSH2_SESSION *session = NULL;
 	php_stream *stream = NULL;
@@ -1249,7 +1248,7 @@ static php_stream *php_ssh2_fopen_wrapper_tunnel(php_stream_wrapper *wrapper, co
 	int port = 0;
 	int resource_id = 0;
 
-	resource = php_ssh2_fopen_wraper_parse_path(path, "tunnel", context, &session, &resource_id, NULL, NULL TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(path, "tunnel", context, &session, &resource_id, NULL, NULL);
 	if (!resource || !session) {
 		return NULL;
 	}
@@ -1285,7 +1284,7 @@ static php_stream *php_ssh2_fopen_wrapper_tunnel(php_stream_wrapper *wrapper, co
 		return NULL;
 	}
 
-	stream = php_ssh2_direct_tcpip(session, resource_id, host, port TSRMLS_CC);
+	stream = php_ssh2_direct_tcpip(session, resource_id, host, port);
 	if (!stream) {
 		// TODO Sean-Der
 		//zend_list_delete(resource_id);
@@ -1323,13 +1322,13 @@ PHP_FUNCTION(ssh2_tunnel)
 	size_t host_len;
 	zend_long port;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rsl", &zsession, &host, &host_len, &port) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rsl", &zsession, &host, &host_len, &port) == FAILURE) {
 		return;
 	}
 
 	SSH2_FETCH_AUTHENTICATED_SESSION(session, zsession);
 
-	stream = php_ssh2_direct_tcpip(session, Z_LVAL_P(zsession), host, port TSRMLS_CC);
+	stream = php_ssh2_direct_tcpip(session, Z_LVAL_P(zsession), host, port);
 	if (!stream) {
 		RETURN_FALSE;
 	}
@@ -1355,19 +1354,19 @@ PHP_FUNCTION(ssh2_fetch_stream)
 	zval *zparent;
 	zend_long streamid;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl", &zparent, &streamid) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &zparent, &streamid) == FAILURE) {
 		return;
 	}
 
 	if (streamid < 0) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid stream ID requested");
+		php_error_docref(NULL, E_WARNING, "Invalid stream ID requested");
 		RETURN_FALSE;
 	}
 
 	php_stream_from_zval(parent, zparent);
 
 	if (parent->ops != &php_ssh2_channel_stream_ops) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Provided stream is not of type " PHP_SSH2_CHANNEL_STREAM_NAME);
+		php_error_docref(NULL, E_WARNING, "Provided stream is not of type " PHP_SSH2_CHANNEL_STREAM_NAME);
 		RETURN_FALSE;
 	}
 
@@ -1379,7 +1378,7 @@ PHP_FUNCTION(ssh2_fetch_stream)
 	}
 
 	if (*(data->refcount) == 255) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Too many streams associated to a single channel");
+		php_error_docref(NULL, E_WARNING, "Too many streams associated to a single channel");
 		RETURN_FALSE;
 	}
 
@@ -1391,7 +1390,7 @@ PHP_FUNCTION(ssh2_fetch_stream)
 
 	stream = php_stream_alloc(&php_ssh2_channel_stream_ops, stream_data, 0, "r+");
 	if (!stream) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error opening substream");
+		php_error_docref(NULL, E_WARNING, "Error opening substream");
 		efree(stream_data);
 		(data->refcount)--;
 		RETURN_FALSE;

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -285,7 +285,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 				sftp_data->session_rsrcid = resource_id;
 				//TODO Sean-Der
 				//zend_list_addref(resource_id);
-				*psftp_rsrcid = zend_register_resource(sftp_data, le_ssh2_sftp)->type;
+				*psftp_rsrcid = zend_register_resource(sftp_data, le_ssh2_sftp)->handle;
 				*psftp = sftp;
 				*presource_id = resource_id;
 				*psession = session;
@@ -333,7 +333,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 				sftp_data->session = session;
 				sftp_data->session_rsrcid = Z_LVAL_P(tmpzval);
 				Z_ADDREF_P(tmpzval);
-				*psftp_rsrcid = zend_register_resource(sftp_data, le_ssh2_sftp)->type;
+				*psftp_rsrcid = zend_register_resource(sftp_data, le_ssh2_sftp)->handle;
 				*psftp = sftp;
 				*presource_id = Z_LVAL_P(tmpzval);
 				*psession = session;

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -50,7 +50,7 @@ void php_ssh2_sftp_dtor(zend_resource *rsrc)
    * SFTP File Ops *
    ***************** */
 
-inline unsigned long php_ssh2_parse_fopen_modes(char *openmode) {
+inline unsigned long php_ssh2_parse_fopen_modes(const char *openmode) {
 	unsigned long flags = 0;
 
 	if (strchr(openmode, 'a')) {
@@ -236,7 +236,7 @@ static php_stream *php_ssh2_sftp_stream_opener(php_stream_wrapper *wrapper, cons
 		return NULL;
 	}
 
-	flags = php_ssh2_parse_fopen_modes((char *)mode);
+	flags = php_ssh2_parse_fopen_modes(mode);
 
 	handle = libssh2_sftp_open(sftp, resource->path, flags, perms);
 	if (!handle) {

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -554,10 +554,6 @@ php_stream_wrapper php_ssh2_sftp_wrapper = {
 	&php_ssh2_sftp_wrapper_ops,
 	NULL,
 	1,
-#if PHP_MAJOR_VERSION <= 5 && PHP_MINOR_VERSION <= 4
-	0,
-	NULL,
-#endif
 };
 
 /* *****************

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -30,7 +30,7 @@
    * Resource Housekeeping *
    ************************* */
 
-void php_ssh2_sftp_dtor(zend_resource *rsrc TSRMLS_DC)
+void php_ssh2_sftp_dtor(zend_resource *rsrc)
 {
 	php_ssh2_sftp_data *data = (php_ssh2_sftp_data*)rsrc->ptr;
 
@@ -106,7 +106,7 @@ typedef struct _php_ssh2_sftp_handle_data {
 
 /* {{{ php_ssh2_sftp_stream_write
  */
-static size_t php_ssh2_sftp_stream_write(php_stream *stream, const char *buf, size_t count TSRMLS_DC)
+static size_t php_ssh2_sftp_stream_write(php_stream *stream, const char *buf, size_t count)
 {
 	php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data*)stream->abstract;
 	ssize_t bytes_written;
@@ -119,7 +119,7 @@ static size_t php_ssh2_sftp_stream_write(php_stream *stream, const char *buf, si
 
 /* {{{ php_ssh2_sftp_stream_read
  */
-static size_t php_ssh2_sftp_stream_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
+static size_t php_ssh2_sftp_stream_read(php_stream *stream, char *buf, size_t count)
 {
 	php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data*)stream->abstract;
 	ssize_t bytes_read;
@@ -134,7 +134,7 @@ static size_t php_ssh2_sftp_stream_read(php_stream *stream, char *buf, size_t co
 
 /* {{{ php_ssh2_sftp_stream_close
  */
-static int php_ssh2_sftp_stream_close(php_stream *stream, int close_handle TSRMLS_DC)
+static int php_ssh2_sftp_stream_close(php_stream *stream, int close_handle)
 {
 	php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data*)stream->abstract;
 
@@ -149,7 +149,7 @@ static int php_ssh2_sftp_stream_close(php_stream *stream, int close_handle TSRML
 
 /* {{{ php_ssh2_sftp_stream_seek
  */
-static int php_ssh2_sftp_stream_seek(php_stream *stream, zend_off_t offset, int whence, zend_off_t *newoffset TSRMLS_DC)
+static int php_ssh2_sftp_stream_seek(php_stream *stream, zend_off_t offset, int whence, zend_off_t *newoffset)
 {
 	php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data*)stream->abstract;
 
@@ -190,7 +190,7 @@ static int php_ssh2_sftp_stream_seek(php_stream *stream, zend_off_t offset, int 
 
 /* {{{ php_ssh2_sftp_stream_fstat
  */
-static int php_ssh2_sftp_stream_fstat(php_stream *stream, php_stream_statbuf *ssb TSRMLS_DC)
+static int php_ssh2_sftp_stream_fstat(php_stream *stream, php_stream_statbuf *ssb)
 {
 	php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data*)stream->abstract;
 	LIBSSH2_SFTP_ATTRIBUTES attrs;
@@ -231,7 +231,7 @@ static php_stream *php_ssh2_sftp_stream_opener(php_stream_wrapper *wrapper, cons
 	unsigned long flags;
 	long perms = 0644;
 
-	resource = php_ssh2_fopen_wraper_parse_path(filename, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(filename, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid);
 	if (!resource || !session || !sftp) {
 		return NULL;
 	}
@@ -240,7 +240,7 @@ static php_stream *php_ssh2_sftp_stream_opener(php_stream_wrapper *wrapper, cons
 
 	handle = libssh2_sftp_open(sftp, resource->path, flags, perms);
 	if (!handle) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to open %s on remote host", filename);
+		php_error_docref(NULL, E_WARNING, "Unable to open %s on remote host", filename);
 		php_url_free(resource);
 		//TODO Sean-Der
 		//zend_list_delete(sftp_rsrcid);
@@ -270,7 +270,7 @@ static php_stream *php_ssh2_sftp_stream_opener(php_stream_wrapper *wrapper, cons
 
 /* {{{ php_ssh2_sftp_dirstream_read
  */
-static size_t php_ssh2_sftp_dirstream_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
+static size_t php_ssh2_sftp_dirstream_read(php_stream *stream, char *buf, size_t count)
 {
 	php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data*)stream->abstract;
 	php_stream_dirent *ent = (php_stream_dirent*)buf;
@@ -298,7 +298,7 @@ static size_t php_ssh2_sftp_dirstream_read(php_stream *stream, char *buf, size_t
 
 /* {{{ php_ssh2_sftp_dirstream_close
  */
-static int php_ssh2_sftp_dirstream_close(php_stream *stream, int close_handle TSRMLS_DC)
+static int php_ssh2_sftp_dirstream_close(php_stream *stream, int close_handle)
 {
 	php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data*)stream->abstract;
 
@@ -336,14 +336,14 @@ static php_stream *php_ssh2_sftp_dirstream_opener(php_stream_wrapper *wrapper, c
 	int resource_id = 0, sftp_rsrcid = 0;
 	php_url *resource;
 
-	resource = php_ssh2_fopen_wraper_parse_path(filename, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(filename, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid);
 	if (!resource || !session || !sftp) {
 		return NULL;
 	}
 
 	handle = libssh2_sftp_opendir(sftp, resource->path);
 	if (!handle) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to open %s on remote host", filename);
+		php_error_docref(NULL, E_WARNING, "Unable to open %s on remote host", filename);
 		php_url_free(resource);
 		//TODO Sean-Der
 		//zend_list_delete(sftp_rsrcid);
@@ -373,7 +373,7 @@ static php_stream *php_ssh2_sftp_dirstream_opener(php_stream_wrapper *wrapper, c
 
 /* {{{ php_ssh2_sftp_urlstat
  */
-static int php_ssh2_sftp_urlstat(php_stream_wrapper *wrapper, const char *url, int flags, php_stream_statbuf *ssb, php_stream_context *context TSRMLS_DC)
+static int php_ssh2_sftp_urlstat(php_stream_wrapper *wrapper, const char *url, int flags, php_stream_statbuf *ssb, php_stream_context *context)
 {
 	LIBSSH2_SFTP_ATTRIBUTES attrs;
 	LIBSSH2_SESSION *session = NULL;
@@ -381,7 +381,7 @@ static int php_ssh2_sftp_urlstat(php_stream_wrapper *wrapper, const char *url, i
 	int resource_id = 0, sftp_rsrcid = 0;
 	php_url *resource;
 
-	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid);
 	if (!resource || !session || !sftp || !resource->path) {
 		return -1;
 	}
@@ -406,7 +406,7 @@ static int php_ssh2_sftp_urlstat(php_stream_wrapper *wrapper, const char *url, i
 
 /* {{{ php_ssh2_sftp_unlink
  */
-static int php_ssh2_sftp_unlink(php_stream_wrapper *wrapper, const char *url, int options, php_stream_context *context TSRMLS_DC)
+static int php_ssh2_sftp_unlink(php_stream_wrapper *wrapper, const char *url, int options, php_stream_context *context)
 {
 	LIBSSH2_SESSION *session = NULL;
 	LIBSSH2_SFTP *sftp = NULL;
@@ -414,7 +414,7 @@ static int php_ssh2_sftp_unlink(php_stream_wrapper *wrapper, const char *url, in
 	php_url *resource;
 	int result;
 
-	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid);
 	if (!resource || !session || !sftp || !resource->path) {
 		if (resource) {
 			php_url_free(resource);
@@ -435,7 +435,7 @@ static int php_ssh2_sftp_unlink(php_stream_wrapper *wrapper, const char *url, in
 
 /* {{{ php_ssh2_sftp_rename
  */
-static int php_ssh2_sftp_rename(php_stream_wrapper *wrapper, const char *url_from, const char *url_to, int options, php_stream_context *context TSRMLS_DC)
+static int php_ssh2_sftp_rename(php_stream_wrapper *wrapper, const char *url_from, const char *url_to, int options, php_stream_context *context)
 {
 	LIBSSH2_SESSION *session = NULL;
 	LIBSSH2_SFTP *sftp = NULL;
@@ -456,7 +456,7 @@ static int php_ssh2_sftp_rename(php_stream_wrapper *wrapper, const char *url_fro
 		return 0;
 	}
 
-	resource = php_ssh2_fopen_wraper_parse_path(url_from, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(url_from, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid);
 	if (!resource || !session || !sftp || !resource->path) {
 		if (resource) {
 			php_url_free(resource);
@@ -479,7 +479,7 @@ static int php_ssh2_sftp_rename(php_stream_wrapper *wrapper, const char *url_fro
 
 /* {{{ php_ssh2_sftp_mkdir
  */
-static int php_ssh2_sftp_mkdir(php_stream_wrapper *wrapper, const char *url, int mode, int options, php_stream_context *context TSRMLS_DC)
+static int php_ssh2_sftp_mkdir(php_stream_wrapper *wrapper, const char *url, int mode, int options, php_stream_context *context)
 {
 	LIBSSH2_SESSION *session = NULL;
 	LIBSSH2_SFTP *sftp = NULL;
@@ -487,7 +487,7 @@ static int php_ssh2_sftp_mkdir(php_stream_wrapper *wrapper, const char *url, int
 	php_url *resource;
 	int result;
 
-	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid);
 	if (!resource || !session || !sftp || !resource->path) {
 		if (resource) {
 			php_url_free(resource);
@@ -516,7 +516,7 @@ static int php_ssh2_sftp_mkdir(php_stream_wrapper *wrapper, const char *url, int
 
 /* {{{ php_ssh2_sftp_rmdir
  */
-static int php_ssh2_sftp_rmdir(php_stream_wrapper *wrapper, const char *url, int options, php_stream_context *context TSRMLS_DC)
+static int php_ssh2_sftp_rmdir(php_stream_wrapper *wrapper, const char *url, int options, php_stream_context *context)
 {
 	LIBSSH2_SESSION *session = NULL;
 	LIBSSH2_SFTP *sftp = NULL;
@@ -524,7 +524,7 @@ static int php_ssh2_sftp_rmdir(php_stream_wrapper *wrapper, const char *url, int
 	php_url *resource;
 	int result;
 
-	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid TSRMLS_CC);
+	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &resource_id, &sftp, &sftp_rsrcid);
 	if (!resource || !session || !sftp || !resource->path) {
 		if (resource) {
 			php_url_free(resource);
@@ -577,7 +577,7 @@ PHP_FUNCTION(ssh2_sftp)
 	php_ssh2_sftp_data *data;
 	zval *zsession;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zsession) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zsession) == FAILURE) {
 		return;
 	}
 
@@ -590,7 +590,7 @@ PHP_FUNCTION(ssh2_sftp)
 		char *sess_err = "Unknown";
 
 		libssh2_session_last_error(session, &sess_err, NULL, 0);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to startup SFTP subsystem: %s", sess_err);
+		php_error_docref(NULL, E_WARNING, "Unable to startup SFTP subsystem: %s", sess_err);
 		RETURN_FALSE;
 	}
 
@@ -614,7 +614,7 @@ PHP_FUNCTION(ssh2_sftp_rename)
 	zval *zsftp;
 	zend_string *src, *dst;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rSS", &zsftp, &src, &dst) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rSS", &zsftp, &src, &dst) == FAILURE) {
 		return;
 	}
 
@@ -635,7 +635,7 @@ PHP_FUNCTION(ssh2_sftp_unlink)
 	zval *zsftp;
 	zend_string *filename;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rS", &zsftp, &filename) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS", &zsftp, &filename) == FAILURE) {
 		return;
 	}
 
@@ -658,7 +658,7 @@ PHP_FUNCTION(ssh2_sftp_mkdir)
 	zend_bool recursive = 0;
 	char *p;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rS|lb", &zsftp, &filename, &mode, &recursive) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS|lb", &zsftp, &filename, &mode, &recursive) == FAILURE) {
 		return;
 	}
 
@@ -694,7 +694,7 @@ PHP_FUNCTION(ssh2_sftp_rmdir)
 	zval *zsftp;
 	zend_string *filename;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rS", &zsftp, &filename) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS", &zsftp, &filename) == FAILURE) {
 		return;
 	}
 
@@ -716,7 +716,7 @@ PHP_FUNCTION(ssh2_sftp_chmod)
 	zend_long mode;
 	LIBSSH2_SFTP_ATTRIBUTES attrs;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rSl", &zsftp, &filename, &mode) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rSl", &zsftp, &filename, &mode) == FAILURE) {
 		return;
 	}
 
@@ -747,7 +747,7 @@ static void php_ssh2_sftp_stat_func(INTERNAL_FUNCTION_PARAMETERS, int stat_type)
 	zval *zsftp;
 	zend_string *path;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rS", &zsftp, &path) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS", &zsftp, &path) == FAILURE) {
 		return;
 	}
 
@@ -756,7 +756,7 @@ static void php_ssh2_sftp_stat_func(INTERNAL_FUNCTION_PARAMETERS, int stat_type)
 	}
 
 	if (libssh2_sftp_stat_ex(data->sftp, path->val, path->len, stat_type, &attrs)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to stat remote file");
+		php_error_docref(NULL, E_WARNING, "Failed to stat remote file");
 		RETURN_FALSE;
 	}
 
@@ -811,7 +811,7 @@ PHP_FUNCTION(ssh2_sftp_symlink)
 	zval *zsftp;
 	zend_string *targ, *link;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rSS", &zsftp, &targ, &link) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rSS", &zsftp, &targ, &link) == FAILURE) {
 		return;
 	}
 
@@ -833,7 +833,7 @@ PHP_FUNCTION(ssh2_sftp_readlink)
 	int targ_len = 0;
 	char targ[8192];
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rS", &zsftp, &link) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS", &zsftp, &link) == FAILURE) {
 		return;
 	}
 
@@ -842,7 +842,7 @@ PHP_FUNCTION(ssh2_sftp_readlink)
 	}
 
 	if ((targ_len = libssh2_sftp_symlink_ex(data->sftp, link->val, link->len, targ, 8192, LIBSSH2_SFTP_READLINK)) < 0) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to read link '%s'", link);
+		php_error_docref(NULL, E_WARNING, "Unable to read link '%s'", link);
 		RETURN_FALSE;
 	}
 
@@ -860,7 +860,7 @@ PHP_FUNCTION(ssh2_sftp_realpath)
 	int targ_len = 0;
 	char targ[8192];
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rS", &zsftp, &link) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS", &zsftp, &link) == FAILURE) {
 		return;
 	}
 
@@ -869,7 +869,7 @@ PHP_FUNCTION(ssh2_sftp_realpath)
 	}
 
 	if ((targ_len = libssh2_sftp_symlink_ex(data->sftp, link->val, link->len, targ, 8192, LIBSSH2_SFTP_REALPATH)) < 0) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to resolve realpath for '%s'", link->val);
+		php_error_docref(NULL, E_WARNING, "Unable to resolve realpath for '%s'", link->val);
 		RETURN_FALSE;
 	}
 

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -204,14 +204,14 @@ static int php_ssh2_sftp_stream_fstat(php_stream *stream, php_stream_statbuf *ss
 /* }}} */
 
 static php_stream_ops php_ssh2_sftp_stream_ops = {
-    php_ssh2_sftp_stream_write,
-    php_ssh2_sftp_stream_read,
-    php_ssh2_sftp_stream_close,
-    NULL, /* flush */
-    PHP_SSH2_SFTP_STREAM_NAME,
-    php_ssh2_sftp_stream_seek,
-    NULL, /* cast */
-    php_ssh2_sftp_stream_fstat,
+	php_ssh2_sftp_stream_write,
+	php_ssh2_sftp_stream_read,
+	php_ssh2_sftp_stream_close,
+	NULL, /* flush */
+	PHP_SSH2_SFTP_STREAM_NAME,
+	php_ssh2_sftp_stream_seek,
+	NULL, /* cast */
+	php_ssh2_sftp_stream_fstat,
 	NULL, /* set_option */
 };
 
@@ -219,7 +219,7 @@ static php_stream_ops php_ssh2_sftp_stream_ops = {
  */
 
 static php_stream *php_ssh2_sftp_stream_opener(php_stream_wrapper *wrapper, const char *filename, const char *mode,
-	    int options, zend_string **opened_path, php_stream_context *context STREAMS_DC)
+		int options, zend_string **opened_path, php_stream_context *context STREAMS_DC)
 {
 	php_ssh2_sftp_handle_data *data;
 	LIBSSH2_SESSION *session = NULL;
@@ -313,12 +313,12 @@ static int php_ssh2_sftp_dirstream_close(php_stream *stream, int close_handle TS
 
 static php_stream_ops php_ssh2_sftp_dirstream_ops = {
 	NULL, /* write */
-    php_ssh2_sftp_dirstream_read,
-    php_ssh2_sftp_dirstream_close,
-    NULL, /* flush */
-    PHP_SSH2_SFTP_DIRSTREAM_NAME,
+	php_ssh2_sftp_dirstream_read,
+	php_ssh2_sftp_dirstream_close,
+	NULL, /* flush */
+	PHP_SSH2_SFTP_DIRSTREAM_NAME,
 	NULL, /* seek */
-    NULL, /* cast */
+	NULL, /* cast */
 	NULL, /* fstat */
 	NULL, /* set_option */
 };
@@ -326,7 +326,7 @@ static php_stream_ops php_ssh2_sftp_dirstream_ops = {
 /* {{{ php_ssh2_sftp_dirstream_opener
  */
 static php_stream *php_ssh2_sftp_dirstream_opener(php_stream_wrapper *wrapper, const char *filename, const char *mode,
-	    int options, zend_string **opened_path, php_stream_context *context STREAMS_DC)
+		int options, zend_string **opened_path, php_stream_context *context STREAMS_DC)
 {
 	php_ssh2_sftp_handle_data *data;
 	LIBSSH2_SESSION *session = NULL;
@@ -580,7 +580,7 @@ PHP_FUNCTION(ssh2_sftp)
 	}
 
 	if ((session = (LIBSSH2_SESSION *)zend_fetch_resource(Z_RES_P(zsession), PHP_SSH2_SESSION_RES_NAME, le_ssh2_session)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	sftp = libssh2_sftp_init(session);
@@ -617,7 +617,7 @@ PHP_FUNCTION(ssh2_sftp_rename)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	RETURN_BOOL(!libssh2_sftp_rename_ex(data->sftp, src->val, src->len, dst->val, dst->len,
@@ -638,7 +638,7 @@ PHP_FUNCTION(ssh2_sftp_unlink)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	RETURN_BOOL(!libssh2_sftp_unlink_ex(data->sftp, filename->val, filename->len));
@@ -665,7 +665,7 @@ PHP_FUNCTION(ssh2_sftp_mkdir)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	if (recursive) {
@@ -697,7 +697,7 @@ PHP_FUNCTION(ssh2_sftp_rmdir)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	RETURN_BOOL(!libssh2_sftp_rmdir_ex(data->sftp, filename->val, filename->len));
@@ -723,7 +723,7 @@ PHP_FUNCTION(ssh2_sftp_chmod)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	attrs.permissions = mode;
@@ -750,7 +750,7 @@ static void php_ssh2_sftp_stat_func(INTERNAL_FUNCTION_PARAMETERS, int stat_type)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	if (libssh2_sftp_stat_ex(data->sftp, path->val, path->len, stat_type, &attrs)) {
@@ -814,7 +814,7 @@ PHP_FUNCTION(ssh2_sftp_symlink)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	RETURN_BOOL(!libssh2_sftp_symlink_ex(data->sftp, targ->val, targ->len, link->val, link->len, LIBSSH2_SFTP_SYMLINK));
@@ -836,7 +836,7 @@ PHP_FUNCTION(ssh2_sftp_readlink)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	if ((targ_len = libssh2_sftp_symlink_ex(data->sftp, link->val, link->len, targ, 8192, LIBSSH2_SFTP_READLINK)) < 0) {
@@ -863,7 +863,7 @@ PHP_FUNCTION(ssh2_sftp_realpath)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
-	    RETURN_FALSE;
+		RETURN_FALSE;
 	}
 
 	if ((targ_len = libssh2_sftp_symlink_ex(data->sftp, link->val, link->len, targ, 8192, LIBSSH2_SFTP_REALPATH)) < 0) {

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -1,22 +1,22 @@
 /*
-  +----------------------------------------------------------------------+
-  | PHP Version 4                                                        |
-  +----------------------------------------------------------------------+
-  | Copyright (c) 1997-2006 The PHP Group                                |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.01 of the PHP license,      |
-  | that is bundled with this package in the file LICENSE, and is        |
-  | available at through the world-wide-web at                           |
-  | http://www.php.net/license/3_01.txt.                                 |
-  | If you did not receive a copy of the PHP license and are unable to   |
-  | obtain it through the world-wide-web, please send a note to          |
-  | license@php.net so we can mail you a copy immediately.               |
-  +----------------------------------------------------------------------+
-  | Author: Sara Golemon <pollita@php.net>                               |
-  +----------------------------------------------------------------------+
-
-  $Id$
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2016 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author: Sara Golemon <pollita@php.net>                               |
+   +----------------------------------------------------------------------+
 */
+
+/* $Id$ */
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -389,6 +389,7 @@ static int php_ssh2_sftp_urlstat(php_stream_wrapper *wrapper, const char *url, i
 	if (libssh2_sftp_stat_ex(sftp, resource->path, strlen(resource->path),
 		(flags & PHP_STREAM_URL_STAT_LINK) ? LIBSSH2_SFTP_LSTAT : LIBSSH2_SFTP_STAT, &attrs)) {
 		php_url_free(resource);
+		// TODO
 		//zend_list_delete(sftp_rsrcid);
 		return -1;
 	}
@@ -396,6 +397,7 @@ static int php_ssh2_sftp_urlstat(php_stream_wrapper *wrapper, const char *url, i
 	php_url_free(resource);
 
 	/* parse_path addrefs the resource, but we're not holding on to it so we have to delref it before we leave */
+	// TODO
 	//zend_list_delete(sftp_rsrcid);
 
 	return php_ssh2_sftp_attr2ssb(ssb, &attrs);
@@ -423,6 +425,7 @@ static int php_ssh2_sftp_unlink(php_stream_wrapper *wrapper, const char *url, in
 	result = libssh2_sftp_unlink(sftp, resource->path);
 	php_url_free(resource);
 
+	// TODO
 	//zend_list_delete(sftp_rsrcid);
 
 	/* libssh2 uses 0 for success and the streams API uses 0 for failure, so invert */
@@ -466,6 +469,7 @@ static int php_ssh2_sftp_rename(php_stream_wrapper *wrapper, const char *url_fro
 	php_url_free(resource);
 	php_url_free(resource_to);
 
+	// TODO
 	//zend_list_delete(sftp_rsrcid);
 
 	/* libssh2 uses 0 for success and the streams API uses 0 for failure, so invert */
@@ -502,6 +506,7 @@ static int php_ssh2_sftp_mkdir(php_stream_wrapper *wrapper, const char *url, int
 	result = libssh2_sftp_mkdir(sftp, resource->path, mode);
 	php_url_free(resource);
 
+	// TODO
 	//zend_list_delete(sftp_rsrcid);
 
 	/* libssh2 uses 0 for success and the streams API uses 0 for failure, so invert */
@@ -530,6 +535,7 @@ static int php_ssh2_sftp_rmdir(php_stream_wrapper *wrapper, const char *url, int
 	result = libssh2_sftp_rmdir(sftp, resource->path);
 	php_url_free(resource);
 
+	// TODO
 	//zend_list_delete(sftp_rsrcid);
 
 	/* libssh2 uses 0 for success and the streams API uses 0 for failure, so invert */


### PR DESCRIPTION
PR fixed and improved the following:
- bugfix handling in ssh2.sftp wrapper with multiple connections (Bug: https://bugs.php.net/bug.php?id=72988)
- remove obsolete code for PHP 7 and remove compatibility with older PHP versions (4.x and 5.x)
- fix raising warning in ssh2_poll
- fix raising erros in ssh2_scp_send
- fix returning values in parse path wrapper function
 

I do not know how fix TODOs with zend_list_addref and zend_list_delete, but all works correctly without fixing this.