### PR TITLE
catching last error

### DIFF
--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -1131,8 +1131,10 @@ PHP_FUNCTION(ssh2_scp_send)
 
 	remote_file = libssh2_scp_send_ex(session, remote_filename, create_mode, ssb.sb.st_size, ssb.sb.st_atime, ssb.sb.st_mtime);
 	if (!remote_file) {
+		int last_error = 0;
 		char *error_msg = NULL;
 
+		last_error = libssh2_session_last_error(session, &error_msg, NULL, 0);
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure creating remote file: %s", error_msg);
 		php_stream_close(local_file);
 		RETURN_FALSE;


### PR DESCRIPTION
This PR returns raising errors. Removed by commit https://github.com/php/pecl-networking-ssh2/commit/f028e8a3710a7a9a1b1e05ceb7790243e11ec4b4.

Splitted from https://github.com/php/pecl-networking-ssh2/pull/14.