### PR TITLE
fix returing psftp_rsrcid value

### DIFF
--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -282,7 +282,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 				sftp_data->session_rsrcid = resource_id;
 				//TODO Sean-Der
 				//zend_list_addref(resource_id);
-				*psftp_rsrcid = zend_register_resource(sftp_data, le_ssh2_sftp)->type;
+				*psftp_rsrcid = zend_register_resource(sftp_data, le_ssh2_sftp)->handle;
 				*psftp = sftp;
 				*presource_id = resource_id;
 				*psession = session;
@@ -330,7 +330,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 				sftp_data->session = session;
 				sftp_data->session_rsrcid = Z_LVAL_P(tmpzval);
 				Z_ADDREF_P(tmpzval);
-				*psftp_rsrcid = zend_register_resource(sftp_data, le_ssh2_sftp)->type;
+				*psftp_rsrcid = zend_register_resource(sftp_data, le_ssh2_sftp)->handle;
 				*psftp = sftp;
 				*presource_id = Z_LVAL_P(tmpzval);
 				*psession = session;


### PR DESCRIPTION
This PR fixed returing psftp_rsrcid value, is needed returning handle from resource. Bug introduced by commit https://github.com/php/pecl-networking-ssh2/commit/d630c5eccae783a7858f00b362b775c0417b56eb.

Splitted from https://github.com/php/pecl-networking-ssh2/pull/14.