### PR TITLE
Cleanup PHP 5 compatibility code in master branch

### DIFF
--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -167,18 +167,6 @@ extern php_stream_wrapper php_ssh2_sftp_wrapper;
 extern int le_ssh2_session;
 extern int le_ssh2_sftp;
 
-/* {{{ ZIP_OPENBASEDIR_CHECKPATH(filename) */
-#if PHP_API_VERSION < 20100412
-# define SSH2_OPENBASEDIR_CHECKPATH(filename) \
-	(PG(safe_mode) && (!php_checkuid(filename, NULL, CHECKUID_CHECK_FILE_AND_DIR))) || php_check_open_basedir(filename TSRMLS_CC)
-#else
-#define SSH2_OPENBASEDIR_CHECKPATH(filename) \
-	php_check_open_basedir(filename TSRMLS_CC)
-#endif
-/* }}} */
-#endif	/* PHP_SSH2_H */
-
-
 /*
  * Local variables:
  * tab-width: 4

--- a/ssh2.c
+++ b/ssh2.c
@@ -665,7 +665,7 @@ PHP_FUNCTION(ssh2_auth_pubkey_file)
 		return;
 	}
 
-	if (SSH2_OPENBASEDIR_CHECKPATH(pubkey) || SSH2_OPENBASEDIR_CHECKPATH(privkey)) {
+	if (php_check_open_basedir(pubkey) || php_check_open_basedir(privkey)) {
 		RETURN_FALSE;
 	}
 
@@ -722,7 +722,7 @@ PHP_FUNCTION(ssh2_auth_hostbased_file)
 		return;
 	}
 
-	if (SSH2_OPENBASEDIR_CHECKPATH(pubkey) || SSH2_OPENBASEDIR_CHECKPATH(privkey)) {
+	if (php_check_open_basedir(pubkey) || php_check_open_basedir(privkey)) {
 		RETURN_FALSE;
 	}
 
@@ -1603,9 +1603,7 @@ zend_function_entry ssh2_functions[] = {
 /* {{{ ssh2_module_entry
  */
 zend_module_entry ssh2_module_entry = {
-#if ZEND_MODULE_API_NO >= 20010901
 	STANDARD_MODULE_HEADER,
-#endif
 	"ssh2",
 	ssh2_functions,
 	PHP_MINIT(ssh2),
@@ -1613,9 +1611,7 @@ zend_module_entry ssh2_module_entry = {
 	NULL, /* RINIT */
 	NULL, /* RSHUTDOWN */
 	PHP_MINFO(ssh2),
-#if ZEND_MODULE_API_NO >= 20010901
 	PHP_SSH2_VERSION,
-#endif
 	STANDARD_MODULE_PROPERTIES
 };
 /* }}} */

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -174,11 +174,9 @@ static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, in
 			return ret;
 			break;
 
-#if PHP_MAJOR_VERSION >= 5
 		case PHP_STREAM_OPTION_CHECK_LIVENESS:
 			return stream->eof = libssh2_channel_eof(abstract->channel);
 			break;
-#endif
 	}
 
 	return -1;
@@ -419,7 +417,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 
 	/* Authenticate */
 	if (pubkey_file && privkey_file) {
-		if (SSH2_OPENBASEDIR_CHECKPATH(pubkey_file) || SSH2_OPENBASEDIR_CHECKPATH(privkey_file)) {
+		if (php_check_open_basedir(pubkey_file) || php_check_open_basedir(privkey_file)) {
 			php_url_free(resource);
 			return NULL;
 		}

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -554,10 +554,6 @@ php_stream_wrapper php_ssh2_sftp_wrapper = {
 	&php_ssh2_sftp_wrapper_ops,
 	NULL,
 	1,
-#if PHP_MAJOR_VERSION <= 5 && PHP_MINOR_VERSION <= 4
-	0,
-	NULL,
-#endif
 };
 
 /* *****************


### PR DESCRIPTION
This PR removing PHP 5 compatibility code in master branch.

Splitted from https://github.com/php/pecl-networking-ssh2/pull/14.