### PR TITLE
BUG_73819: call ssh2_shell() causes segment fault

### DIFF
--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -118,8 +118,8 @@ typedef struct _php_ssh2_channel_data {
 	char is_blocking;
 	long timeout;
 
-	/* Resource ID, zend_list_addref() when opening, zend_list_delete() when closing */
-	long session_rsrc;
+	/* Resource ID */
+	int session_rsrcid;
 
 	/* Allow one stream to be closed while the other is kept open */
 	unsigned char *refcount;

--- a/ssh2.c
+++ b/ssh2.c
@@ -810,7 +810,7 @@ PHP_FUNCTION(ssh2_forward_accept)
 	channel_data->channel = channel;
 	channel_data->streamid = 0;
 	channel_data->is_blocking = 0;
-	channel_data->session_rsrc = data->session_rsrcid;
+	channel_data->session_rsrcid = data->session_rsrcid;
 	channel_data->refcount = NULL;
 
 	stream = php_stream_alloc(&php_ssh2_channel_stream_ops, channel_data, 0, "r+");
@@ -821,7 +821,7 @@ PHP_FUNCTION(ssh2_forward_accept)
 		RETURN_FALSE;
 	}
 	//TODO Sean-Der
-	//zend_list_addref(channel_data->session_rsrc);
+	//zend_list_addref(channel_data->session_rsrcid);
 
 	php_stream_to_zval(stream, return_value);
 }
@@ -975,7 +975,7 @@ PHP_FUNCTION(ssh2_publickey_init)
 
 	data = emalloc(sizeof(php_ssh2_pkey_subsys_data));
 	data->session = session;
-	data->session_rsrcid = Z_LVAL_P(zsession);
+	data->session_rsrcid = Z_RES_P(zsession)->handle;
 	//TODO Sean-Der
 	//zend_list_addref(data->session_rsrcid);
 	data->pkey = pkey;

--- a/tests/ssh2_shell.phpt
+++ b/tests/ssh2_shell.phpt
@@ -1,0 +1,24 @@
+--TEST--
+ssh2_shell_test() - Tests opening a shell
+--SKIPIF--
+<?php require('ssh2_skip.inc'); ssh2t_needs_auth(); ?>
+--FILE--
+<?php require('ssh2_test.inc');
+
+$ssh = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+var_dump(ssh2t_auth($ssh));
+$shell = ssh2_shell($ssh);
+var_dump($shell);
+
+fwrite( $shell, 'echo "foo bar"'.PHP_EOL);
+sleep(1);
+while($line = fgets($shell)) {
+    echo $line;
+}
+
+--EXPECTF--
+bool(true)
+resource(%d) of type (stream)
+%a
+foo bar
+%a


### PR DESCRIPTION
1. php_ssh2_shell_open() was calling zend_hash_get_current_key_ex
2. php_ssh2_exec_command() / php_ssh2_shell_open() / php_ssh2_direct_tcpip()
   were being passed a pointer instead of the resource ID.
3. Renamed session_rsrc to session_rsrcid
3. Added test for ssh2_shell and reading / writing to the stream