### PR TITLE
Adding Travis CI to pecl-networking-ssh2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: required
+dist: trusty
+
+language: php
+php:
+    - 7.0
+
+addons:
+    apt:
+        packages:
+            - libssh2-1
+            - libssh2-1-dev
+
+env:
+    global:
+        - TEST_SSH2_HOSTNAME=localhost
+        - TEST_SSH2_USER=sshuser
+        - TEST_SSH2_PASS=sshpassword
+        - REPORT_EXIT_STATUS=1
+
+script:
+    - ./.travis/build.sh

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+
+sudo adduser --disabled-password --gecos "" sshuser
+echo "sshuser:sshpassword" | sudo chpasswd
+
+phpize
+./configure
+make
+make install
+
+php -d variables_order=EGPCS run-tests.php -p $(which php) -d extension=$(pwd)/modules/ssh2.so -d variables_order=EGPCS -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --show-diff --offline --set-timeout 120


### PR DESCRIPTION
This PR will allow automated testing with Travis CI. 

If an admin for this repo just enables TravisCI, automated testing will occur on merges and PRs.

Here is an example of a successful run from my repo:
https://travis-ci.org/mhagstrand/pecl-networking-ssh2/builds/199552224

