### PR TITLE
Fix multiple reflection/documentation disparities

### DIFF
--- a/ssh2.c
+++ b/ssh2.c
@@ -703,7 +703,7 @@ PHP_FUNCTION(ssh2_auth_pubkey_file)
 }
 /* }}} */
 
-/* {{{ proto bool ssh2_auth_hostbased_file(resource session, string username, string local_hostname, string pubkeyfile, string privkeyfile[, string passphrase[, string local_username]])
+/* {{{ proto bool ssh2_auth_hostbased_file(resource session, string username, string hostname, string pubkeyfile, string privkeyfile[, string passphrase[, string local_username]])
  * Authenticate using a hostkey
  */
 PHP_FUNCTION(ssh2_auth_hostbased_file)
@@ -1369,21 +1369,23 @@ PHP_MINFO_FUNCTION(ssh2)
 
 /* {{{ ZEND_BEGIN_ARG_INFO
  */
-ZEND_BEGIN_ARG_INFO(arginfo_ssh2_connect, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_connect, 0, 0, 1)
  	ZEND_ARG_INFO(0, host)
  	ZEND_ARG_INFO(0, port)
+ 	ZEND_ARG_INFO(0, methods)
+ 	ZEND_ARG_INFO(0, callbacks)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_ssh2_disconnect, 1)
- 	ZEND_ARG_INFO(0, resource)
+ 	ZEND_ARG_INFO(0, session)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_ssh2_methods_negotiated, 1)
- 	ZEND_ARG_INFO(0, resource)
+ 	ZEND_ARG_INFO(0, session)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_fingerprint, 0, 0, 2)
- 	ZEND_ARG_INFO(0, resource)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_fingerprint, 0, 0, 1)
+ 	ZEND_ARG_INFO(0, session)
  	ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 
@@ -1449,14 +1451,14 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_scp_send, 0, 0, 3)
  	ZEND_ARG_INFO(0, session)
- 	ZEND_ARG_INFO(0, remote_file)
  	ZEND_ARG_INFO(0, local_file)
+ 	ZEND_ARG_INFO(0, remote_file)
  	ZEND_ARG_INFO(0, create_mode)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_ssh2_fetch_stream, 2)
  	ZEND_ARG_INFO(0, channel)
- 	ZEND_ARG_INFO(0, stream_id)
+ 	ZEND_ARG_INFO(0, streamid)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_ssh2_sftp, 1)

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -904,7 +904,7 @@ php_stream_wrapper php_ssh2_stream_wrapper_exec = {
 	0
 };
 
-/* {{{ proto stream ssh2_exec(resource session, string command[, string pty[, array env[, int width[, int heightp[, int width_height_type]]]]])
+/* {{{ proto stream ssh2_exec(resource session, string command[, string pty[, array env[, int width[, int height[, int width_height_type]]]]])
  * Execute a command at the remote end and allocate a channel for it
  *
  * This function has a dirty little secret.... pty and env can be in either order.... shhhh... don't tell anyone

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -641,22 +641,22 @@ PHP_FUNCTION(ssh2_sftp_unlink)
 }
 /* }}} */
 
-/* {{{ proto bool ssh2_sftp_mkdir(resource sftp, string filename[, int mode[, int recursive]])
+/* {{{ proto bool ssh2_sftp_mkdir(resource sftp, string dirname[, int mode[, int recursive]])
  */
 PHP_FUNCTION(ssh2_sftp_mkdir)
 {
 	php_ssh2_sftp_data *data;
 	zval *zsftp;
-	zend_string *filename;
+	zend_string *dirname;
 	zend_long mode = 0777;
 	zend_bool recursive = 0;
 	char *p;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS|lb", &zsftp, &filename, &mode, &recursive) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS|lb", &zsftp, &dirname, &mode, &recursive) == FAILURE) {
 		return;
 	}
 
-	if (!filename) {
+	if (!dirname) {
 		RETURN_FALSE;
 	}
 
@@ -666,29 +666,29 @@ PHP_FUNCTION(ssh2_sftp_mkdir)
 
 	if (recursive) {
 		/* Just attempt to make every directory, some will fail, but we only care about the last success/failure */
-		p = filename->val;
+		p = dirname->val;
 		while ((p = strchr(p + 1, '/'))) {
-			if ((p - filename->val) + 1 == filename->len) {
+			if ((p - dirname->val) + 1 == dirname->len) {
 				break;
 			}
-			libssh2_sftp_mkdir_ex(data->sftp, filename->val, p - filename->val, mode);
+			libssh2_sftp_mkdir_ex(data->sftp, dirname->val, p - dirname->val, mode);
 		}
 	}
 
 
-	RETURN_BOOL(!libssh2_sftp_mkdir_ex(data->sftp, filename->val, filename->len, mode));
+	RETURN_BOOL(!libssh2_sftp_mkdir_ex(data->sftp, dirname->val, dirname->len, mode));
 }
 /* }}} */
 
-/* {{{ proto bool ssh2_sftp_rmdir(resource sftp, string filename)
+/* {{{ proto bool ssh2_sftp_rmdir(resource sftp, string dirname)
  */
 PHP_FUNCTION(ssh2_sftp_rmdir)
 {
 	php_ssh2_sftp_data *data;
 	zval *zsftp;
-	zend_string *filename;
+	zend_string *dirname;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS", &zsftp, &filename) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS", &zsftp, &dirname) == FAILURE) {
 		return;
 	}
 
@@ -696,7 +696,7 @@ PHP_FUNCTION(ssh2_sftp_rmdir)
 		RETURN_FALSE;
 	}
 
-	RETURN_BOOL(!libssh2_sftp_rmdir_ex(data->sftp, filename->val, filename->len));
+	RETURN_BOOL(!libssh2_sftp_rmdir_ex(data->sftp, dirname->val, dirname->len));
 }
 /* }}} */
 


### PR DESCRIPTION
Multiple reflection or documentation disparities fixed:
* ssh2_connect
  * added missing parameters
  * only first parameter is required
* ssh2_disconnect
  * renamed reflection parameter according to doc & other functions
* ssh2_methods_negotiated
  * renamed reflection parameter according to doc & other functions
* ssh2_fingerprint
  * renamed reflection parameter according to doc & other functions
  * second parameter is optional
* ssh2_scp_send
  * swap parameters according to docs
* ssh2_fetch_stream
  * rename reflection parameter according to docs
* ssh2_sftp_mkdir
  * sync parameter & variable name according to docs
* ssh2_sftp_rmdir
  * sync parameter & variable name according to docs