### PR TITLE
PHP 7.3 only compatibility

### DIFF
--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -110,6 +110,13 @@ if (!libssh2_userauth_authenticated(session)) { \
 	RETURN_FALSE; \
 }
 
+/* compatibility */
+#if PHP_VERSION_ID < 70300
+#define SSH2_URL_STR(a) (a)
+#else
+#define SSH2_URL_STR(a) ZSTR_VAL(a)
+#endif
+
 typedef struct _php_ssh2_channel_data {
 	LIBSSH2_CHANNEL *channel;
 

--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -73,14 +73,14 @@ typedef struct _php_ssh2_sftp_data {
 	LIBSSH2_SESSION *session;
 	LIBSSH2_SFTP *sftp;
 
-	int session_rsrcid;
+	zend_resource *session_rsrc;
 } php_ssh2_sftp_data;
 
 typedef struct _php_ssh2_listener_data {
 	LIBSSH2_SESSION *session;
 	LIBSSH2_LISTENER *listener;
 
-	int session_rsrcid;
+	zend_resource *session_rsrc;
 } php_ssh2_listener_data;
 
 #include "libssh2_publickey.h"
@@ -89,7 +89,7 @@ typedef struct _php_ssh2_pkey_subsys_data {
 	LIBSSH2_SESSION *session;
 	LIBSSH2_PUBLICKEY *pkey;
 
-	int session_rsrcid;
+	zend_resource *session_rsrc;
 } php_ssh2_pkey_subsys_data;
 
 #define SSH2_FETCH_NONAUTHENTICATED_SESSION(session, zsession) \
@@ -118,8 +118,8 @@ typedef struct _php_ssh2_channel_data {
 	char is_blocking;
 	long timeout;
 
-	/* Resource ID */
-	int session_rsrcid;
+	/* Resource */
+	zend_resource *session_rsrc;
 
 	/* Allow one stream to be closed while the other is kept open */
 	unsigned char *refcount;
@@ -151,8 +151,8 @@ PHP_FUNCTION(ssh2_sftp_realpath);
 LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, zval *callbacks);
 void php_ssh2_sftp_dtor(zend_resource *rsrc);
 php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stream_context *context,
-											LIBSSH2_SESSION **psession, int *presource_id,
-											LIBSSH2_SFTP **psftp, int *psftp_rsrcid);
+											LIBSSH2_SESSION **psession, zend_resource **presource,
+											LIBSSH2_SFTP **psftp, zend_resource **psftp_rsrc);
 
 extern php_stream_ops php_ssh2_channel_stream_ops;
 

--- a/ssh2.c
+++ b/ssh2.c
@@ -819,8 +819,8 @@ PHP_FUNCTION(ssh2_forward_accept)
 		libssh2_channel_free(channel);
 		RETURN_FALSE;
 	}
-
-	GC_REFCOUNT(channel_data->session_rsrc)++;
+	// For PHP 7.3
+	GC_ADDREF(channel_data->session_rsrc);
 
 	php_stream_to_zval(stream, return_value);
 }

--- a/ssh2.c
+++ b/ssh2.c
@@ -819,8 +819,11 @@ PHP_FUNCTION(ssh2_forward_accept)
 		libssh2_channel_free(channel);
 		RETURN_FALSE;
 	}
-	// For PHP 7.3
+#if PHP_VERSION_ID < 70300
+	GC_REFCOUNT(channel_data->session_rsrc)++;
+#else
 	GC_ADDREF(channel_data->session_rsrc);
+#endif
 
 	php_stream_to_zval(stream, return_value);
 }

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -225,23 +225,23 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 	} else {
 		resource = php_url_parse(path);
 	}
-	if (!resource || !ZSTR_VAL(resource->path)) {
+	if (!resource || !SSH2_URL_STR(resource->path)) {
 		return NULL;
 	}
 
-	if (strncmp(ZSTR_VAL(resource->scheme), "ssh2.", sizeof("ssh2.") - 1)) {
+	if (strncmp(SSH2_URL_STR(resource->scheme), "ssh2.", sizeof("ssh2.") - 1)) {
 		/* Not an ssh wrapper */
 		php_url_free(resource);
 		return NULL;
 	}
 
-	if (strcmp(ZSTR_VAL(resource->scheme) + sizeof("ssh2.") - 1, type)) {
+	if (strcmp(SSH2_URL_STR(resource->scheme) + sizeof("ssh2.") - 1, type)) {
 		/* Wrong ssh2. wrapper type */
 		php_url_free(resource);
 		return NULL;
 	}
 
-	if (!ZSTR_VAL(resource->host)) {
+	if (!SSH2_URL_STR(resource->host)) {
 		return NULL;
 	}
 
@@ -251,14 +251,14 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 		xxxx
 	*/
        	zs = resource->path;
-	s = estrdup(strstr(path, ZSTR_VAL(resource->path)));
+	s = estrdup(strstr(path, SSH2_URL_STR(resource->path)));
        	resource->path = zend_string_init(s, sizeof(s)-1, 0);
 	efree(s);
-	/* resource->path = estrdup(strstr(path, resource->path ? ZSTR_VAL(resource->path) : NULL)); */
+	/* resource->path = estrdup(strstr(path, resource->path ? SSH2_URL_STR(resource->path) : NULL)); */
 	zend_string_release(zs);
 
 	/* Look for a resource ID to reuse a session */
-	s = ZSTR_VAL(resource->host);
+	s = SSH2_URL_STR(resource->host);
 	if (is_numeric_string(s, strlen(s), &resource_id, NULL, 0) == IS_LONG) {
 		php_ssh2_sftp_data *sftp_data;
 		zval *zresource;
@@ -306,7 +306,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 	}
 
 	/* Fallback on finding it in the context */
-	if (ZSTR_VAL(resource->host)[0] == 0 && context && psftp &&
+	if (SSH2_URL_STR(resource->host)[0] == 0 && context && psftp &&
 		(tmpzval = php_stream_context_get_option(context, "ssh2", "sftp")) != NULL &&
 		Z_TYPE_P(tmpzval) == IS_RESOURCE) {
 		php_ssh2_sftp_data *sftp_data;
@@ -320,7 +320,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 			return resource;
 		}
 	}
-	if (ZSTR_VAL(resource->host)[0] == 0 && context &&
+	if (SSH2_URL_STR(resource->host)[0] == 0 && context &&
 		(tmpzval = php_stream_context_get_option(context, "ssh2", "session")) != NULL &&
 		Z_TYPE_P(tmpzval) == IS_RESOURCE) {
 		session = (LIBSSH2_SESSION *)zend_fetch_resource(Z_RES_P(tmpzval), PHP_SSH2_SESSION_RES_NAME, le_ssh2_session);
@@ -395,20 +395,20 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 		privkey_file = Z_STRVAL_P(tmpzval);
 	}
 
-	if (ZSTR_VAL(resource->user)) {
+	if (SSH2_URL_STR(resource->user)) {
 		int len = ZSTR_LEN(resource->user);
 
 		if (len) {
-			username = ZSTR_VAL(resource->user);
+			username = SSH2_URL_STR(resource->user);
 			username_len = len;
 		}
 	}
 
-	if (ZSTR_VAL(resource->pass)) {
+	if (SSH2_URL_STR(resource->pass)) {
 		int len = ZSTR_LEN(resource->pass);
 
 		if (len) {
-			password = ZSTR_VAL(resource->pass);
+			password = SSH2_URL_STR(resource->pass);
 			password_len = len;
 		}
 	}
@@ -419,7 +419,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 		return NULL;
 	}
 
-	session = php_ssh2_session_connect(ZSTR_VAL(resource->host), resource->port, methods, callbacks);
+	session = php_ssh2_session_connect(SSH2_URL_STR(resource->host), resource->port, methods, callbacks);
 	if (!session) {
 		/* Unable to connect! */
 		php_url_free(resource);
@@ -627,7 +627,7 @@ static php_stream *php_ssh2_fopen_wrapper_shell(php_stream_wrapper *wrapper, con
 		zval_ptr_dtor(&copyval);
 	}
 
-	s = ZSTR_VAL(resource->path);
+	s = SSH2_URL_STR(resource->path);
 
 	if (s && s[0] == '/') {
 		/* Terminal type encoded into URL overrides context terminal type */
@@ -828,7 +828,7 @@ static php_stream *php_ssh2_fopen_wrapper_exec(php_stream_wrapper *wrapper, cons
 	if (!resource || !session) {
 		return NULL;
 	}
-	if (!ZSTR_VAL(resource->path)) {
+	if (!SSH2_URL_STR(resource->path)) {
 		php_url_free(resource);
 		zend_list_delete(rsrc);
 		return NULL;
@@ -872,7 +872,7 @@ static php_stream *php_ssh2_fopen_wrapper_exec(php_stream_wrapper *wrapper, cons
 		zval_ptr_dtor(copyval);
 	}
 
-	stream = php_ssh2_exec_command(session, rsrc, ZSTR_VAL(resource->path) + 1, terminal, terminal_len, environment, width, height, type);
+	stream = php_ssh2_exec_command(session, rsrc, SSH2_URL_STR(resource->path) + 1, terminal, terminal_len, environment, width, height, type);
 	if (!stream) {
 		zend_list_delete(rsrc);
 	}
@@ -1007,13 +1007,13 @@ static php_stream *php_ssh2_fopen_wrapper_scp(php_stream_wrapper *wrapper, const
 	if (!resource || !session) {
 		return NULL;
 	}
-	if (!ZSTR_VAL(resource->path)) {
+	if (!SSH2_URL_STR(resource->path)) {
 		php_url_free(resource);
 		zend_list_delete(rsrc);
 		return NULL;
 	}
 
-	stream = php_ssh2_scp_xfer(session, rsrc, ZSTR_VAL(resource->path));
+	stream = php_ssh2_scp_xfer(session, rsrc, SSH2_URL_STR(resource->path));
 	if (!stream) {
 		zend_list_delete(rsrc);
 	}
@@ -1253,10 +1253,10 @@ static php_stream *php_ssh2_fopen_wrapper_tunnel(php_stream_wrapper *wrapper, co
 		return NULL;
 	}
 
-	if (ZSTR_VAL(resource->path) && ZSTR_VAL(resource->path)[0] == '/') {
+	if (SSH2_URL_STR(resource->path) && SSH2_URL_STR(resource->path)[0] == '/') {
 		char *colon;
 
-		host = ZSTR_VAL(resource->path) + 1;
+		host = SSH2_URL_STR(resource->path) + 1;
 		if (*host == '[') {
 			/* IPv6 Encapsulated Format */
 			host++;

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -236,7 +236,7 @@ static php_stream *php_ssh2_sftp_stream_opener(php_stream_wrapper *wrapper, cons
 
 	flags = php_ssh2_parse_fopen_modes((char *)mode);
 
-	handle = libssh2_sftp_open(sftp, resource->path, flags, perms);
+	handle = libssh2_sftp_open(sftp, ZSTR_VAL(resource->path), flags, perms);
 	if (!handle) {
 		php_error_docref(NULL, E_WARNING, "Unable to open %s on remote host", filename);
 		php_url_free(resource);
@@ -336,7 +336,7 @@ static php_stream *php_ssh2_sftp_dirstream_opener(php_stream_wrapper *wrapper, c
 		return NULL;
 	}
 
-	handle = libssh2_sftp_opendir(sftp, resource->path);
+	handle = libssh2_sftp_opendir(sftp, ZSTR_VAL(resource->path));
 	if (!handle) {
 		php_error_docref(NULL, E_WARNING, "Unable to open %s on remote host", filename);
 		php_url_free(resource);
@@ -375,7 +375,7 @@ static int php_ssh2_sftp_urlstat(php_stream_wrapper *wrapper, const char *url, i
 	php_url *resource;
 
 	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
-	if (!resource || !session || !sftp || !resource->path) {
+	if (!resource || !session || !sftp || !ZSTR_VAL(resource->path)) {
 		return -1;
 	}
 
@@ -406,14 +406,14 @@ static int php_ssh2_sftp_unlink(php_stream_wrapper *wrapper, const char *url, in
 	int result;
 
 	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
-	if (!resource || !session || !sftp || !resource->path) {
+	if (!resource || !session || !sftp || !ZSTR_VAL(resource->path)) {
 		if (resource) {
 			php_url_free(resource);
 		}
 		return 0;
 	}
 
-	result = libssh2_sftp_unlink(sftp, resource->path);
+	result = libssh2_sftp_unlink(sftp, ZSTR_VAL(resource->path));
 	php_url_free(resource);
 
 	//zend_list_delete(sftp_rsrcid);
@@ -439,7 +439,7 @@ static int php_ssh2_sftp_rename(php_stream_wrapper *wrapper, const char *url_fro
 	}
 
 	resource_to = php_url_parse(url_to);
-	if (!resource_to || !resource_to->path) {
+	if (!resource_to || !ZSTR_VAL(resource_to->path)) {
 		if (resource_to) {
 			php_url_free(resource_to);
 		}
@@ -447,7 +447,7 @@ static int php_ssh2_sftp_rename(php_stream_wrapper *wrapper, const char *url_fro
 	}
 
 	resource = php_ssh2_fopen_wraper_parse_path(url_from, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
-	if (!resource || !session || !sftp || !resource->path) {
+	if (!resource || !session || !sftp || !ZSTR_VAL(resource->path)) {
 		if (resource) {
 			php_url_free(resource);
 		}
@@ -455,7 +455,7 @@ static int php_ssh2_sftp_rename(php_stream_wrapper *wrapper, const char *url_fro
 		return 0;
 	}
 
-	result = libssh2_sftp_rename(sftp, resource->path, resource_to->path);
+	result = libssh2_sftp_rename(sftp, ZSTR_VAL(resource->path), ZSTR_VAL(resource_to->path));
 	php_url_free(resource);
 	php_url_free(resource_to);
 
@@ -477,7 +477,7 @@ static int php_ssh2_sftp_mkdir(php_stream_wrapper *wrapper, const char *url, int
 	int result;
 
 	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
-	if (!resource || !session || !sftp || !resource->path) {
+	if (!resource || !session || !sftp || !ZSTR_VAL(resource->path)) {
 		if (resource) {
 			php_url_free(resource);
 		}
@@ -486,13 +486,13 @@ static int php_ssh2_sftp_mkdir(php_stream_wrapper *wrapper, const char *url, int
 
 	if (options & PHP_STREAM_MKDIR_RECURSIVE) {
 		/* Just attempt to make every directory, some will fail, but we only care about the last success/failure */
-		char *p = resource->path;
+		char *p = ZSTR_VAL(resource->path);
 		while ((p = strchr(p + 1, '/'))) {
-			libssh2_sftp_mkdir_ex(sftp, resource->path, p - resource->path, mode);
+			libssh2_sftp_mkdir_ex(sftp, ZSTR_VAL(resource->path), p - ZSTR_VAL(resource->path), mode);
 		}
 	}
 
-	result = libssh2_sftp_mkdir(sftp, resource->path, mode);
+	result = libssh2_sftp_mkdir(sftp, ZSTR_VAL(resource->path), mode);
 	php_url_free(resource);
 
 	//zend_list_delete(sftp_rsrcid);
@@ -513,7 +513,7 @@ static int php_ssh2_sftp_rmdir(php_stream_wrapper *wrapper, const char *url, int
 	int result;
 
 	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
-	if (!resource || !session || !sftp || !resource->path) {
+	if (!resource || !session || !sftp || !ZSTR_VAL(resource->path)) {
 		if (resource) {
 			php_url_free(resource);
 		}
@@ -630,7 +630,7 @@ PHP_FUNCTION(ssh2_sftp_unlink)
 		RETURN_FALSE;
 	}
 
-	RETURN_BOOL(!libssh2_sftp_unlink_ex(data->sftp, filename->val, filename->len));
+	RETURN_BOOL(!libssh2_sftp_unlink_ex(data->sftp, ZSTR_VAL(filename), ZSTR_LEN(filename)));
 }
 /* }}} */
 


### PR DESCRIPTION
This PR combines the two other PR's:

1. Fixed PHP7 port. Restored commented reference counting.
https://github.com/php/pecl-networking-ssh2/pull/30 by @dstogov

2. Updates for php_url structure changes (make failed on 7.3).
https://github.com/php/pecl-networking-ssh2/pull/31 by @DanielCiochiu 

And it changes GC_REFCOUNT(p)++  into GC_ADDREF(p) cf https://github.com/php/php-src/blob/master/UPGRADING.INTERNALS#L81

Note the PR is for PHP 7.3 only.