### PR TITLE
Remove inline from php_ssh2_sftp_attr2ssb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 sudo: required
-dist: trusty
+dist: bionic
 
 language: php
 php:
-    - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
 
 addons:
     apt:

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -73,7 +73,7 @@ unsigned long php_ssh2_parse_fopen_modes(char *openmode) {
 	return flags;
 }
 
-inline int php_ssh2_sftp_attr2ssb(php_stream_statbuf *ssb, LIBSSH2_SFTP_ATTRIBUTES *attrs)
+static inline int php_ssh2_sftp_attr2ssb(php_stream_statbuf *ssb, LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
 	memset(ssb, 0, sizeof(php_stream_statbuf));
 	if (attrs->flags & LIBSSH2_SFTP_ATTR_SIZE) {


### PR DESCRIPTION
That were fixed in https://github.com/php/pecl-networking-ssh2/commit/073067ba96ac99ed5696d27f13ca6c8124986e74#diff-d0296647d3a59f029c56a9154f65ab01R52
But this inline still causing build issues

PS: related to https://github.com/alpinelinux/aports/pull/6226 and http://clang.llvm.org/compatibility.html#inline