### PR TITLE
Adding support for stream_select to shell streams

### DIFF
--- a/tests/ssh2_stream_select.phpt
+++ b/tests/ssh2_stream_select.phpt
@@ -1,0 +1,36 @@
+--TEST--
+ssh2_stream_select() - Tests opening a shell and using stream_select
+--SKIPIF--
+<?php require('ssh2_skip.inc'); ssh2t_needs_auth(); ?>
+--FILE--
+<?php require('ssh2_test.inc');
+
+$ssh = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+var_dump(ssh2t_auth($ssh));
+$shell = ssh2_shell($ssh);
+var_dump($shell);
+
+fwrite($shell, 'echo "howdy"' . PHP_EOL);
+sleep(1);
+
+$read = [$shell];
+$write = null;
+$except = null;
+$timeout = 5;
+$start = time();
+if (stream_select($read, $write, $except, $timeout) !== false && count($read) > 0) {
+	while($line = fgets($shell)) {
+	    echo $line;
+	}
+}
+$elapsed = time() - $start;
+var_dump(($elapsed < $timeout));
+
+--EXPECTF--
+bool(true)
+resource(%d) of type (stream)
+%a
+%a
+%a
+howdy
+%sbool(true)


### PR DESCRIPTION
PHP streams provide access to the select() system call via stream_select() for streams which can be cast as socket and/or file descriptors. This change implements the cast function provided to PHP stream resources representing SSH2 shell sessions, or those obtained via ssh2_shell. 

The cast funtion simply yields the socket established during ssh2_connect for the purposes of enabling PHP's stream_select() to indicate read readiness on the SSH2 shell stream. Note that data available on the socket does not necessarily indicate data available on the shell stream's underlying LIBSSH2_CHANNEL object, as protocol data is filtered. Callers must be aware that no data may be available to read on the shell stream despite positive indication from stream_select(). The rate of such false positives is thought to be low.

Presently, attempts to invoke stream_select() on SSH2 shell streams yields the following warnings:

Warning: stream_select(): cannot represent a stream of type SSH2 Channel as a select()able descriptor in /repos/ssh2/tests/ssh2_stream_select.php on line 21

Warning: stream_select(): No stream arrays were passed in /repos/ssh2/tests/ssh2_stream_select.php on line 21


Given the long-deprecated state of libssh2_poll, and the recommendation therein to use poll() or select() system calls instead, this change is thought to be prudent.

References:
https://www.libssh2.org/libssh2_poll.html
https://bugs.php.net/bug.php?id=58974
https://github.com/php/php-src/blob/master/docs/streams.md#casting-streams
