### PR TITLE
Fix compatibility with PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
+    - nightly
 
 addons:
     apt:

--- a/ssh2.c
+++ b/ssh2.c
@@ -45,10 +45,6 @@ int le_ssh2_listener;
 int le_ssh2_sftp;
 int le_ssh2_pkey_subsys;
 
-ZEND_BEGIN_ARG_INFO(php_ssh2_first_arg_force_ref, 0)
-	ZEND_ARG_PASS_INFO(1)
-ZEND_END_ARG_INFO()
-
 /* *************
    * Callbacks *
    ************* */
@@ -1416,6 +1412,19 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_auth_hostbased_file, 0, 0, 5)
  	ZEND_ARG_INFO(0, local_username)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_forward_listen, 0, 0, 2)
+ 	ZEND_ARG_INFO(0, session)
+ 	ZEND_ARG_INFO(0, port)
+ 	ZEND_ARG_INFO(0, host)
+ 	ZEND_ARG_INFO(0, max_connections)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_forward_accept, 0, 0, 1)
+ 	ZEND_ARG_INFO(0, listener)
+ 	ZEND_ARG_INFO(1, host)
+ 	ZEND_ARG_INFO(0, port)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_shell, 0, 0, 1)
  	ZEND_ARG_INFO(0, session)
  	ZEND_ARG_INFO(0, termtype)
@@ -1457,6 +1466,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_ssh2_fetch_stream, 2)
  	ZEND_ARG_INFO(0, channel)
  	ZEND_ARG_INFO(0, streamid)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_poll, 0, 0, 1)
+ 	ZEND_ARG_INFO(1, polldes)
+ 	ZEND_ARG_INFO(0, timeout)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_ssh2_sftp, 1)
@@ -1559,8 +1573,8 @@ zend_function_entry ssh2_functions[] = {
 	PHP_FE(ssh2_auth_pubkey_file,				arginfo_ssh2_auth_pubkey_file)
 	PHP_FE(ssh2_auth_hostbased_file,			arginfo_ssh2_auth_hostbased_file)
 
-	PHP_FE(ssh2_forward_listen,					NULL)
-	PHP_FE(ssh2_forward_accept,					NULL)
+	PHP_FE(ssh2_forward_listen,					arginfo_ssh2_forward_listen)
+	PHP_FE(ssh2_forward_accept,					arginfo_ssh2_forward_accept)
 
 	/* Stream Stuff */
 	PHP_FE(ssh2_shell,							arginfo_ssh2_shell)
@@ -1569,7 +1583,7 @@ zend_function_entry ssh2_functions[] = {
 	PHP_FE(ssh2_scp_recv,						arginfo_ssh2_scp_recv)
 	PHP_FE(ssh2_scp_send,						arginfo_ssh2_scp_send)
 	PHP_FE(ssh2_fetch_stream,					arginfo_ssh2_fetch_stream)
-	PHP_FE(ssh2_poll,							php_ssh2_first_arg_force_ref)
+	PHP_FE(ssh2_poll,							arginfo_ssh2_poll)
 
 	/* SFTP Stuff */
 	PHP_FE(ssh2_sftp,							arginfo_ssh2_sftp)

--- a/ssh2.c
+++ b/ssh2.c
@@ -100,7 +100,7 @@ LIBSSH2_DEBUG_FUNC(php_ssh2_debug_cb)
 	ZVAL_STRINGL(&args[1], language, language_len);
 	ZVAL_LONG(&args[2], always_display);
 
-	if (FAILURE == call_user_function_ex(NULL, NULL, data->disconnect_cb, NULL, 3, args, 0, NULL)) {
+	if (FAILURE == call_user_function(NULL, NULL, data->disconnect_cb, NULL, 3, args)) {
 		php_error_docref(NULL, E_WARNING, "Failure calling disconnect callback");
 	}
 }
@@ -125,7 +125,7 @@ LIBSSH2_IGNORE_FUNC(php_ssh2_ignore_cb)
 
 	ZVAL_STRINGL(&args[0], message, message_len);
 
-	if (FAILURE == call_user_function_ex(NULL, NULL, data->ignore_cb, &zretval, 1, args, 0, NULL)) {
+	if (FAILURE == call_user_function(NULL, NULL, data->ignore_cb, &zretval, 1, args)) {
 		php_error_docref(NULL, E_WARNING, "Failure calling ignore callback");
 	}
 	if (Z_TYPE_P(&zretval) != IS_UNDEF) {
@@ -155,7 +155,7 @@ LIBSSH2_MACERROR_FUNC(php_ssh2_macerror_cb)
 
 	ZVAL_STRINGL(&args[0], packet, packet_len);
 
-	if (FAILURE == call_user_function_ex(NULL, NULL, data->macerror_cb, &zretval, 1, args, 0, NULL)) {
+	if (FAILURE == call_user_function(NULL, NULL, data->macerror_cb, &zretval, 1, args)) {
 		php_error_docref(NULL, E_WARNING, "Failure calling macerror callback");
 	} else {
 		retval = zval_is_true(&zretval) ? 0 : -1;
@@ -188,7 +188,7 @@ LIBSSH2_DISCONNECT_FUNC(php_ssh2_disconnect_cb)
 	ZVAL_STRINGL(&args[1], message, message_len);
 	ZVAL_STRINGL(&args[2], language, language_len);
 
-	if (FAILURE == call_user_function_ex(NULL, NULL, data->disconnect_cb, NULL, 3, args, 0, NULL)) {
+	if (FAILURE == call_user_function(NULL, NULL, data->disconnect_cb, NULL, 3, args)) {
 		php_error_docref(NULL, E_WARNING, "Failure calling disconnect callback");
 	}
 }


### PR DESCRIPTION
Ref https://github.com/php/php-src/commit/302933daea77663f5759b10accd1d0231393b24c 

https://github.com/php/php-src/blob/master/UPGRADING.INTERNALS#L140

> The zend_fcall_info no_separation flag has been removed, and separation is
>     never allowed. If you wish to pass (or allow passing) arguments by
>     reference, explicitly create those arguments as references using
>     ZEND_MAKE_REF. This removal also affects call_user_function_ex(), which
>     should be replaced by call_user_function().