### PR TITLE
Add ssh2_send_eof function

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -72,6 +72,7 @@
                 <file role="test" name="ssh2_exec.phpt"/>
                 <file role="test" name="ssh2_sftp_001.phpt"/>
                 <file role="test" name="ssh2_sftp_002.phpt"/>
+                <file role="test" name="ssh2_send_eof.phpt"/>
                 <file role="test" name="ssh2_shell.phpt"/>
                 <file role="test" name="ssh2_skip.inc"/>
                 <file role="test" name="ssh2_test.inc"/>

--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -131,6 +131,7 @@ PHP_FUNCTION(ssh2_tunnel);
 PHP_FUNCTION(ssh2_scp_recv);
 PHP_FUNCTION(ssh2_scp_send);
 PHP_FUNCTION(ssh2_fetch_stream);
+PHP_FUNCTION(ssh2_send_eof);
 
 /* In ssh2_sftp.c */
 PHP_FUNCTION(ssh2_sftp);

--- a/ssh2.c
+++ b/ssh2.c
@@ -1459,6 +1459,10 @@ ZEND_BEGIN_ARG_INFO(arginfo_ssh2_fetch_stream, 2)
  	ZEND_ARG_INFO(0, streamid)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_send_eof, 0, 0, 1)
+	ZEND_ARG_INFO(0, channel)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_ssh2_sftp, 1)
  	ZEND_ARG_INFO(0, session)
 ZEND_END_ARG_INFO()
@@ -1569,6 +1573,7 @@ zend_function_entry ssh2_functions[] = {
 	PHP_FE(ssh2_scp_recv,						arginfo_ssh2_scp_recv)
 	PHP_FE(ssh2_scp_send,						arginfo_ssh2_scp_send)
 	PHP_FE(ssh2_fetch_stream,					arginfo_ssh2_fetch_stream)
+	PHP_FE(ssh2_send_eof,						arginfo_ssh2_send_eof)
 	PHP_FE(ssh2_poll,							php_ssh2_first_arg_force_ref)
 
 	/* SFTP Stuff */

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -1405,6 +1405,44 @@ PHP_FUNCTION(ssh2_fetch_stream)
 }
 /* }}} */
 
+/* {{{ proto stream ssh2_send_eof(stream channel)
+ * Sends EOF to a stream. Primary use is to close stdin of an stdio stream.
+ */
+PHP_FUNCTION(ssh2_send_eof)
+{
+	php_ssh2_channel_data *data;
+	php_stream *parent;
+	zval *zparent;
+	int ssh2_ret;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zparent) == FAILURE) {
+		return;
+	}
+
+	php_stream_from_zval(parent, zparent);
+	if (parent->ops != &php_ssh2_channel_stream_ops) {
+		php_error_docref(NULL, E_WARNING, "Provided stream is not of type " PHP_SSH2_CHANNEL_STREAM_NAME);
+		RETURN_FALSE;
+	}
+
+	data = (php_ssh2_channel_data*)parent->abstract;
+	if (!data) {
+		php_error_docref(NULL, E_WARNING, "Abstract in stream is null");
+		RETURN_FALSE;
+	}
+
+	ssh2_ret = libssh2_channel_send_eof(data->channel);
+	if (ssh2_ret < 0) {
+		char msg[256];
+		snprintf(msg, 256, "Couldn't send EOF to channel (Return code %d)", ssh2_ret);
+		php_error_docref(NULL, E_WARNING, msg);
+		RETURN_FALSE;
+	}
+
+	RETURN_TRUE;
+}
+/* }}} */
+
 /*
  * Local variables:
  * tab-width: 4

--- a/tests/ssh2_send_eof.phpt
+++ b/tests/ssh2_send_eof.phpt
@@ -1,0 +1,32 @@
+--TEST--
+ssh2_send_eof() - Tests closing standard input
+--SKIPIF--
+<?php require('ssh2_skip.inc'); ssh2t_needs_auth(); ?>
+--FILE--
+<?php require('ssh2_test.inc');
+
+$ssh = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+var_dump(ssh2t_auth($ssh));
+
+$cmd=ssh2_exec($ssh, 'cat' . PHP_EOL);
+
+var_dump($cmd);
+
+stream_set_blocking($cmd, true);
+
+$content = "foo";
+
+fwrite($cmd, $content);
+fflush($cmd);
+ssh2_send_eof($cmd);
+
+$response = stream_get_contents($cmd);
+var_dump($response === $content);
+echo $response . PHP_EOL;
+
+--EXPECTF--
+bool(true)
+resource(%d) of type (stream)
+bool(true)
+foo
+


### PR DESCRIPTION
Without this, you can't close the standard input stream without also closing the standard output stream. One can try to redirect
standard output to error, but having a reference on the error stream keeps a reference on the stdio stream, so closing stdio
won't decrement the reference count enough to actually close the stream.

This makes it possible to use programs over SSH that take their input over standard input without any temporary files/redirection, and get the output back over standard output.