### PR TITLE
Fix #79631: SSH disconnect segfault with SFTP (assertion failed)

### DIFF
--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -36,7 +36,9 @@ void php_ssh2_sftp_dtor(zend_resource *rsrc)
 		return;
 	}
 
-	libssh2_sftp_shutdown(data->sftp);
+	if (data->session_rsrc->ptr != NULL) {
+		libssh2_sftp_shutdown(data->sftp);
+	}
 
 	zend_list_delete(data->session_rsrc);
 
@@ -870,6 +872,10 @@ PHP_FUNCTION(ssh2_sftp_realpath)
 	}
 
 	if ((data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) == NULL) {
+		RETURN_FALSE;
+	}
+
+	if (data->session_rsrc->ptr == NULL) {
 		RETURN_FALSE;
 	}
 

--- a/tests/bug79631.phpt
+++ b/tests/bug79631.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug 79631 (SSH disconnect segfault with SFTP (assertion failed))
+--SKIPIF--
+<?php
+require('ssh2_skip.inc');
+ssh2t_needs_auth();
+ssh2t_writes_remote();
+?>
+--FILE--
+<?php
+require('ssh2_test.inc');
+
+$ssh = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+ssh2t_auth($ssh);
+$sftp = ssh2_sftp($ssh);
+ssh2_disconnect($ssh);
+echo "done\n";
+?>
+--EXPECT--
+done


### PR DESCRIPTION
If the SSH2 Session resource has already been closed, the libssh2
session has been as well, and the `LIBSSH2_SESSION*` has been set NULL.
If that is the case, we must not call `libssh2_sftp_shutdown()`.

---

Note that this patch only resolves the particular shutdown issue, but does not generally address using the SSH2 SFTP resource after the SSH2 Session resource has been closed (i.e. calling any of the `ssh2_sftp_*()` functions after `ssh2_disconnect($ssh)` still segfaults).  This would have to be handled for every `ssh2_sftp_*()` function individually.  If you like, I can amend this PR respectively, or submit another PR. But maybe there is a more elegant solution I'm missing?