### PR TITLE
Fix #63480: Warning on using the SSH2 Session resource in the uri

### DIFF
--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -310,7 +310,8 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 		}
 
 		if (psftp) {
-			sftp_data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zresource), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp);
+			/* suppress potential warning by passing NULL as resource_type_name */
+			sftp_data = (php_ssh2_sftp_data *)zend_fetch_resource(Z_RES_P(zresource), NULL, le_ssh2_sftp);
 			if (sftp_data) {
 				/* Want the sftp layer */
 				Z_ADDREF_P(zresource);

--- a/tests/bug63480.phpt
+++ b/tests/bug63480.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #63480 (Warning on using the SSH2 Session resource in the uri)
+--SKIPIF--
+<?php
+require('ssh2_skip.inc');
+ssh2t_needs_auth();
+ssh2t_writes_remote();
+?>
+--FILE--
+<?php
+require('ssh2_test.inc');
+
+$ssh = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+ssh2t_auth($ssh);
+
+$filename = ssh2t_tempnam();
+file_put_contents("ssh2.sftp://$ssh/$filename", "yada yada");
+
+readfile("ssh2.sftp://$ssh/$filename");
+
+unlink("ssh2.sftp://$ssh/$filename");
+?>
+--EXPECT--
+yada yada


### PR DESCRIPTION
There is no need to warn if an SSH2 Session resource is given, so we
suppress the potential warning by passing NULL as `resource_type_name`.