### PR TITLE
Fix #80294: ssh2 wrappers not using an allocated resource segfault

### DIFF
--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -498,8 +498,7 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 	return NULL;
 
 session_authed:
-	//TODO Sean-Der
-	//ZEND_REGISTER_RESOURCE(&zsession, session, le_ssh2_session);
+	ZVAL_RES(&zsession, zend_register_resource(session, le_ssh2_session));
 
 	if (psftp) {
 		LIBSSH2_SFTP *sftp;


### PR DESCRIPTION
We need to properly initialize the SSH2 Session resource.