### PR TITLE
Fix #75523: stream_set_timeout(): No support for ssh2 stream timeout

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -37,6 +37,7 @@ if (PHP_SSH2 != "no") {
         EXTENSION("ssh2", "ssh2.c ssh2_fopen_wrappers.c ssh2_sftp.c");
         AC_DEFINE('HAVE_SSH2LIB', 1);
         AC_DEFINE('PHP_SSH2_AGENT_AUTH', 1);
+        AC_DEFINE('PHP_SSH2_SESSION_TIMEOUT', 1);
         ADD_EXTENSION_DEP('ssh2', 'zlib')
         ADD_EXTENSION_DEP('ssh2', 'openssl')
     }


### PR DESCRIPTION
Obviously, the appropriate define is not done in config.w32, although
libssh2 1.4.2 is available for Windows builds as of 2012-09-20.  For
current PHP versions libssh2 1.9.0 is used on Windows.