### PR TITLE
Fix line ending in test case when running on Windows

### DIFF
--- a/tests/ssh2_send_eof.phpt
+++ b/tests/ssh2_send_eof.phpt
@@ -8,7 +8,7 @@ ssh2_send_eof() - Tests closing standard input
 $ssh = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
 var_dump(ssh2t_auth($ssh));
 
-$cmd=ssh2_exec($ssh, 'cat' . PHP_EOL);
+$cmd=ssh2_exec($ssh, "cat\n");
 
 var_dump($cmd);
 

--- a/tests/ssh2_stream_select.phpt
+++ b/tests/ssh2_stream_select.phpt
@@ -10,7 +10,7 @@ var_dump(ssh2t_auth($ssh));
 $shell = ssh2_shell($ssh);
 var_dump($shell);
 
-fwrite($shell, 'echo "howdy"' . PHP_EOL);
+fwrite($shell, "echo \"howdy\"\n");
 sleep(1);
 
 $read = [$shell];


### PR DESCRIPTION
This test case executes `cat` and uses `PHP_EOL` as line ending.  This
causes the test to fail when executed on Windows connected to a Linux
SSH server.  Since `cat` is usually not available on Windows, running
the test would fail if a Windows SSH server was used.  Thus, we can
easily fix this by always using LF.