### PR TITLE
Fix #80729: ssh2_shell() streams are not stream_select()able

### DIFF
--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -22,6 +22,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 #include "ext/standard/url.h"
+#include "main/php_network.h"
 
 #define PHP_SSH2_VERSION				"1.2"
 #define PHP_SSH2_DEFAULT_PORT			22
@@ -64,7 +65,7 @@ typedef struct _php_ssh2_session_data {
 	zval *macerror_cb;
 	zval *disconnect_cb;
 
-	int socket;
+	php_socket_t socket;
 } php_ssh2_session_data;
 
 typedef struct _php_ssh2_sftp_data {

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -171,7 +171,7 @@ static int php_ssh2_channel_stream_cast(php_stream *stream, int castas, void **r
 		case PHP_STREAM_AS_FD_FOR_SELECT:
 		case PHP_STREAM_AS_SOCKETD:
 			if (ret) {
-				*(int *)ret = (*session_data)->socket;
+				*(php_socket_t *)ret = (*session_data)->socket;
 			}
 			return SUCCESS;
 		default:


### PR DESCRIPTION
On Windows, the socket type is not an `int` but rather `SOCKET` which
is actually `unsigned int` on x86 and `unsigned __int64` on x64.  To
cater to this type mismatch, PHP offers the portable `php_socket_t` (at
least as of PHP 5.0.0).  We use it for `php_ssh2_session_data` as well.

---

Note that this patch constitutes an ABI break, and as such likely needs to be postponed to the next major version. :(