### PR TITLE
ssh2_sftp: remove implicit switch-case fallthrough in stream_seek

### DIFF
--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -179,6 +179,7 @@ static int php_ssh2_sftp_stream_seek(php_stream *stream, zend_off_t offset, int 
 				return -1;
 			}
 			offset += attrs.filesize;
+			break;
 		}
 		case SEEK_CUR:
 		{
@@ -189,6 +190,7 @@ static int php_ssh2_sftp_stream_seek(php_stream *stream, zend_off_t offset, int 
 			}
 
 			offset += current_offset;
+			break;
 		}
 	}
 


### PR DESCRIPTION
On [release 1.4](https://pecl.php.net/package-info.php?package=ssh2&version=1.4), we got warnings for implicit fallthroughs:

```
/builds/php/ext/ssh2/ssh2_sftp.c:172:3: warning: this statement may fall through [-Wimplicit-fallthrough=]
  172 |   {
      |   ^
/builds/php/ext/ssh2/ssh2_sftp.c:183:3: note: here
  183 |   case SEEK_CUR:
      |   ^~~~
```

([permalink](https://github.com/php/pecl-networking-ssh2/blob/520e1f0810f226c7ea0290b9b3db77242d96157c/ssh2_sftp.c#L170-L193))