### PR TITLE
End zend_function_entry ssh2_functions list with PHP_FE_END

### DIFF
--- a/ssh2.c
+++ b/ssh2.c
@@ -1656,7 +1656,7 @@ zend_function_entry ssh2_functions[] = {
 
 	PHP_FE(ssh2_auth_agent,						arginfo_ssh2_auth_agent)
 
-	{NULL, NULL, NULL}
+	PHP_FE_END
 };
 /* }}} */
 


### PR DESCRIPTION
This prevents a compile-time warning about missing field initializations. It's also consistent with the use of `PHP_FE` (internally alias of `ZEND_FE`)