### PR TITLE
ssh2_fopen_wrappers: initialize php_stream_wrapper_ops explicitly

### DIFF
--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -720,7 +720,12 @@ static php_stream_wrapper_ops php_ssh2_shell_stream_wops = {
 	NULL, /* stat */
 	NULL, /* stat_url */
 	NULL, /* opendir */
-	"ssh2.shell"
+	"ssh2.shell", /* label */
+	NULL, /* unlink */
+	NULL, /* rename */
+	NULL, /* mkdir */
+	NULL, /* rmdir */
+	NULL  /* stream_metadata */
 };
 
 php_stream_wrapper php_ssh2_stream_wrapper_shell = {

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -969,7 +969,12 @@ static php_stream_wrapper_ops php_ssh2_exec_stream_wops = {
 	NULL, /* stat */
 	NULL, /* stat_url */
 	NULL, /* opendir */
-	"ssh2.exec"
+	"ssh2.exec",  /* label */
+        NULL, /* unlink */
+        NULL, /* rename */
+        NULL, /* mkdir */
+        NULL, /* rmdir */
+        NULL  /* stream_metadata */
 };
 
 php_stream_wrapper php_ssh2_stream_wrapper_exec = {
@@ -1110,7 +1115,12 @@ static php_stream_wrapper_ops php_ssh2_scp_stream_wops = {
 	NULL, /* stat */
 	NULL, /* stat_url */
 	NULL, /* opendir */
-	"ssh2.scp"
+	"ssh2.scp",  /* label */
+        NULL, /* unlink */
+        NULL, /* rename */
+        NULL, /* mkdir */
+        NULL, /* rmdir */
+        NULL  /* stream_metadata */
 };
 
 php_stream_wrapper php_ssh2_stream_wrapper_scp = {
@@ -1380,7 +1390,12 @@ static php_stream_wrapper_ops php_ssh2_tunnel_stream_wops = {
 	NULL, /* stat */
 	NULL, /* stat_url */
 	NULL, /* opendir */
-	"ssh2.tunnel"
+	"ssh2.tunnel",  /* label */
+        NULL, /* unlink */
+        NULL, /* rename */
+        NULL, /* mkdir */
+        NULL, /* rmdir */
+        NULL  /* stream_metadata */
 };
 
 php_stream_wrapper php_ssh2_stream_wrapper_tunnel = {

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -554,15 +554,16 @@ static int php_ssh2_sftp_rmdir(php_stream_wrapper *wrapper, const char *url, int
 
 static php_stream_wrapper_ops php_ssh2_sftp_wrapper_ops = {
 	php_ssh2_sftp_stream_opener,
-	NULL, /* close */
+	NULL, /* stream_close */
 	NULL, /* stat */
-	php_ssh2_sftp_urlstat,
-	php_ssh2_sftp_dirstream_opener,
-	PHP_SSH2_SFTP_WRAPPER_NAME,
-	php_ssh2_sftp_unlink,
-	php_ssh2_sftp_rename,
-	php_ssh2_sftp_mkdir,
-	php_ssh2_sftp_rmdir,
+	php_ssh2_sftp_urlstat, /* stat_url */
+	php_ssh2_sftp_dirstream_opener, /* opendir */
+	PHP_SSH2_SFTP_WRAPPER_NAME, /* label */
+	php_ssh2_sftp_unlink, /* unlink */
+	php_ssh2_sftp_rename, /* rename */
+	php_ssh2_sftp_mkdir, /* mkdir */
+	php_ssh2_sftp_rmdir, /* rmdir */
+	NULL /* stream_metadata */
 };
 
 php_stream_wrapper php_ssh2_sftp_wrapper = {


### PR DESCRIPTION
This prevents compile-time warnings about missing field initializers.