### PR TITLE
Typofix (php_ssh2_fopen_wrap[p]er_parse_path)

### DIFF
--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -151,7 +151,7 @@ PHP_FUNCTION(ssh2_sftp_realpath);
 
 LIBSSH2_SESSION *php_ssh2_session_connect(char *host, int port, zval *methods, zval *callbacks);
 void php_ssh2_sftp_dtor(zend_resource *rsrc);
-php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stream_context *context,
+php_url *php_ssh2_fopen_wrapper_parse_path(const char *path, char *type, php_stream_context *context,
 											LIBSSH2_SESSION **psession, zend_resource **presource,
 											LIBSSH2_SFTP **psftp, zend_resource **psftp_rsrc);
 

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -230,10 +230,10 @@ php_stream_ops php_ssh2_channel_stream_ops = {
    * Magic Path Helper *
    ********************* */
 
-/* {{{ php_ssh2_fopen_wraper_parse_path
+/* {{{ php_ssh2_fopen_wrapper_parse_path
  * Parse an ssh2.*:// path
  */
-php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stream_context *context,
+php_url *php_ssh2_fopen_wrapper_parse_path(const char *path, char *type, php_stream_context *context,
 											LIBSSH2_SESSION **psession, zend_resource **presource,
 											LIBSSH2_SFTP **psftp, zend_resource **psftp_rsrc)
 {
@@ -630,7 +630,7 @@ static php_stream *php_ssh2_fopen_wrapper_shell(php_stream_wrapper *wrapper, con
 	php_url *resource;
 	char *s;
 
-	resource = php_ssh2_fopen_wraper_parse_path(path, "shell", context, &session, &rsrc, NULL, NULL);
+	resource = php_ssh2_fopen_wrapper_parse_path(path, "shell", context, &session, &rsrc, NULL, NULL);
 	if (!resource || !session) {
 		return NULL;
 	}
@@ -900,7 +900,7 @@ static php_stream *php_ssh2_fopen_wrapper_exec(php_stream_wrapper *wrapper, cons
 	long height = PHP_SSH2_DEFAULT_TERM_HEIGHT;
 	long type = PHP_SSH2_DEFAULT_TERM_UNIT;
 
-	resource = php_ssh2_fopen_wraper_parse_path(path, "exec", context, &session, &rsrc, NULL, NULL);
+	resource = php_ssh2_fopen_wrapper_parse_path(path, "exec", context, &session, &rsrc, NULL, NULL);
 	if (!resource || !session) {
 		return NULL;
 	}
@@ -1079,7 +1079,7 @@ static php_stream *php_ssh2_fopen_wrapper_scp(php_stream_wrapper *wrapper, const
 		return NULL;
 	}
 
-	resource = php_ssh2_fopen_wraper_parse_path(path, "scp", context, &session, &rsrc, NULL, NULL);
+	resource = php_ssh2_fopen_wrapper_parse_path(path, "scp", context, &session, &rsrc, NULL, NULL);
 	if (!resource || !session) {
 		return NULL;
 	}
@@ -1324,7 +1324,7 @@ static php_stream *php_ssh2_fopen_wrapper_tunnel(php_stream_wrapper *wrapper, co
 	int port = 0;
 	zend_resource *rsrc;
 
-	resource = php_ssh2_fopen_wraper_parse_path(path, "tunnel", context, &session, &rsrc, NULL, NULL);
+	resource = php_ssh2_fopen_wrapper_parse_path(path, "tunnel", context, &session, &rsrc, NULL, NULL);
 	if (!resource || !session) {
 		return NULL;
 	}

--- a/ssh2_sftp.c
+++ b/ssh2_sftp.c
@@ -247,7 +247,7 @@ static php_stream *php_ssh2_sftp_stream_opener(php_stream_wrapper *wrapper, cons
 	unsigned long flags;
 	long perms = 0644;
 
-	resource = php_ssh2_fopen_wraper_parse_path(filename, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
+	resource = php_ssh2_fopen_wrapper_parse_path(filename, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
 	if (!resource || !session || !sftp || !sftp_rsrc) {
 		return NULL;
 	}
@@ -353,7 +353,7 @@ static php_stream *php_ssh2_sftp_dirstream_opener(php_stream_wrapper *wrapper, c
 	zend_resource *rsrc = NULL, *sftp_rsrc = NULL;
 	php_url *resource;
 
-	resource = php_ssh2_fopen_wraper_parse_path(filename, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
+	resource = php_ssh2_fopen_wrapper_parse_path(filename, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
 	if (!resource || !session || !sftp) {
 		return NULL;
 	}
@@ -396,7 +396,7 @@ static int php_ssh2_sftp_urlstat(php_stream_wrapper *wrapper, const char *url, i
 	zend_resource *rsrc = NULL, *sftp_rsrc = NULL;
 	php_url *resource;
 
-	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
+	resource = php_ssh2_fopen_wrapper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
 	if (!resource || !session || !sftp || !resource->path) {
 		return -1;
 	}
@@ -427,7 +427,7 @@ static int php_ssh2_sftp_unlink(php_stream_wrapper *wrapper, const char *url, in
 	php_url *resource;
 	int result;
 
-	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
+	resource = php_ssh2_fopen_wrapper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
 	if (!resource || !session || !sftp || !resource->path) {
 		if (resource) {
 			php_url_free(resource);
@@ -468,7 +468,7 @@ static int php_ssh2_sftp_rename(php_stream_wrapper *wrapper, const char *url_fro
 		return 0;
 	}
 
-	resource = php_ssh2_fopen_wraper_parse_path(url_from, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
+	resource = php_ssh2_fopen_wrapper_parse_path(url_from, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
 	if (!resource || !session || !sftp || !resource->path) {
 		if (resource) {
 			php_url_free(resource);
@@ -498,7 +498,7 @@ static int php_ssh2_sftp_mkdir(php_stream_wrapper *wrapper, const char *url, int
 	php_url *resource;
 	int result;
 
-	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
+	resource = php_ssh2_fopen_wrapper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
 	if (!resource || !session || !sftp || !resource->path) {
 		if (resource) {
 			php_url_free(resource);
@@ -534,7 +534,7 @@ static int php_ssh2_sftp_rmdir(php_stream_wrapper *wrapper, const char *url, int
 	php_url *resource;
 	int result;
 
-	resource = php_ssh2_fopen_wraper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
+	resource = php_ssh2_fopen_wrapper_parse_path(url, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
 	if (!resource || !session || !sftp || !resource->path) {
 		if (resource) {
 			php_url_free(resource);


### PR DESCRIPTION
This was introduced in 946ee797a53bd90b63d1d51cf99a2978d1e4f403 a long time ago (the initial release).

Apart from some forks on Github, I do not see any use of this function outside of this package.