### PR TITLE
Fixed issue with ssh2_poll function throwing error on valid input

### DIFF
--- a/ssh2.c
+++ b/ssh2.c
@@ -911,8 +911,7 @@ PHP_FUNCTION(ssh2_poll)
 
 		pollfds[i].events = Z_LVAL_P(tmpzval);
 		hash_key_zstring = zend_string_init("resource", sizeof("resource") - 1, 0);
-		if ((tmpzval = zend_hash_find(Z_ARRVAL_P(subarray), hash_key_zstring)) == NULL || Z_TYPE_P(tmpzval) != IS_REFERENCE
-			|| (tmpzval = Z_REFVAL_P(tmpzval)) == NULL || Z_TYPE_P(tmpzval) != IS_RESOURCE) {
+		if ((tmpzval = zend_hash_find(Z_ARRVAL_P(subarray), hash_key_zstring)) == NULL || Z_TYPE_P(tmpzval) != IS_RESOURCE) {
 			php_error_docref(NULL, E_WARNING, "Invalid data in subarray, no resource element, or not of type resource");
 			numfds--;
 			zend_string_release(hash_key_zstring);


### PR DESCRIPTION
`ssh2_poll` function checks for input arguments and fails on valid stream resource with error `PHP Warning:  ssh2_poll(): Invalid data in subarray, no resource element, or not of type resource`.

Here is a PHP function which is in use in our development environment to basically do everything from building to deploying and used in many of our internal tools. On Windows `stream_select` occasionally will loop indefinitely without receiving `eof` nor `timeout`. I tried to switch to `ssh2_poll`, but the function contains invalid `resource` check. I've built it from source and corrected the issue. Now the function works as indented and haven't experienced any loops.

Commented code is for using `stream_select`.

```php
/**
 * Executes remote command synchronously
 *
 * @param string $command
 * @param string|null &$output
 * @param string|null &$error
 * @return bool
 */
public function exec(string $command, ?string &$output, ?string &$error): bool
{
    $stream = ssh2_exec($this->_connection, $command);
    $errorStream = ssh2_fetch_stream($stream, SSH2_STREAM_STDERR);

    stream_set_blocking($stream, true);
    stream_set_blocking($errorStream, true);

    $outputChunks = array();
    $errorChunks = array();

    $eof = function ($s) use ($command) {
        $meta = stream_get_meta_data($s);
        // Occasionally `stream_select` after command won't receive `eof` nor `to` and loops indefinitely.
        Msg::write(' [' . var_export($meta['eof'], true) . ',' . var_export($meta['timed_out'], true) . ']', false, ColorFG::Blue);
        return $meta['eof'] || $meta['timed_out'];
    };

    do {
        $read = array($stream, $errorStream);
//            $write = null;
//            $except = null;

        $polldest = array(
            array(
                'resource' => $stream,
                'events' => SSH2_POLLOUT,
            ),
            array(
                'resource' => $errorStream,
                'events' => SSH2_POLLOUT,
            ),
        );

        //if (stream_select($read, $write, $except, 5)) {
        if (ssh2_poll($polldest, 5)) {
            foreach ($read as $c) {
                if (feof($c)) {
                    continue;
                }
                $read = stream_get_line($c, 8192);

                if ($read === false) {
                    continue;
                }

                if ($c === $stream) {
                    $chunks = &$outputChunks;
                } else {
                    $chunks = &$errorChunks;
                }
                $chunks[] = $read;

                while ($line = stream_get_line($c, 8192)) {
                    $chunks[] = $line;
                }
            }
        }
    } while (!$eof($stream) | !$eof($errorStream));

    fclose($stream);
    fclose($errorStream);

    $output = implode($outputChunks);
    $error = implode($errorChunks);

    unset($outputChunks); // free up large chunks
    unset($errorChunks);

    if ((strlen($output) == 0 && strlen($error) == 0) || strlen($output) > 0) {
        return true;
    } else {
        return false;
    }
}
```