### PR TITLE
Fix sftp streamwrapper not correctly handeling freestanding urls; fixes #85

### DIFF
--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -501,9 +501,8 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path, char *type, php_stre
 session_authed:
 	ZVAL_RES(&zsession, zend_register_resource(session, le_ssh2_session));
 
-	if (psftp) {
+	if (psftp && psftp_rsrc) {
 		LIBSSH2_SFTP *sftp;
-		zval zsftp;
 
 		sftp = libssh2_sftp_init(session);
 		if (!sftp) {
@@ -516,10 +515,8 @@ session_authed:
 		sftp_data->session = session;
 		sftp_data->sftp = sftp;
 		sftp_data->session_rsrc = Z_RES(zsession);
-
-		//TODO Sean-Der
-		//ZEND_REGISTER_RESOURCE(sftp_data, le_ssh2_sftp);
-		*psftp_rsrc = Z_RES(zsftp);
+		Z_ADDREF(zsession);
+		*psftp_rsrc = zend_register_resource(sftp_data, le_ssh2_sftp);
 		*psftp = sftp;
 	}
 


### PR DESCRIPTION
For an explanation, see #85 .