### PR TITLE
Fix call to ssh2_auth_pubkey[_file]() without password

### DIFF
--- a/ssh2.c
+++ b/ssh2.c
@@ -653,7 +653,7 @@ PHP_FUNCTION(ssh2_auth_pubkey_file)
 {
 	LIBSSH2_SESSION *session;
 	zval *zsession;
-	zend_string *username, *pubkey, *privkey, *passphrase;
+	zend_string *username, *pubkey, *privkey, *passphrase = NULL;
 #ifndef PHP_WIN32
 	zend_string *newpath;
 	struct passwd *pws;
@@ -689,7 +689,7 @@ PHP_FUNCTION(ssh2_auth_pubkey_file)
 #endif
 
 	/* TODO: Support passphrase callback */
-	if (libssh2_userauth_publickey_fromfile_ex(session, ZSTR_VAL(username), ZSTR_LEN(username), ZSTR_VAL(pubkey), ZSTR_VAL(privkey), ZSTR_VAL(passphrase))) {
+	if (libssh2_userauth_publickey_fromfile_ex(session, ZSTR_VAL(username), ZSTR_LEN(username), ZSTR_VAL(pubkey), ZSTR_VAL(privkey), passphrase ? ZSTR_VAL(passphrase) : NULL)) {
 		char *buf;
 		int len;
 		libssh2_session_last_error(session, &buf, &len, 0);

--- a/ssh2.c
+++ b/ssh2.c
@@ -709,7 +709,7 @@ PHP_FUNCTION(ssh2_auth_pubkey)
 {
 	LIBSSH2_SESSION *session;
 	zval *zsession;
-	zend_string *username, *pubkey, *privkey, *passphrase;
+	zend_string *username, *pubkey, *privkey, *passphrase = NULL;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rSSS|S", &zsession,	&username, &pubkey, &privkey, &passphrase) == FAILURE) {
 		return;
@@ -717,7 +717,7 @@ PHP_FUNCTION(ssh2_auth_pubkey)
 
 	SSH2_FETCH_NONAUTHENTICATED_SESSION(session, zsession);
 
-	if (libssh2_userauth_publickey_frommemory(session, ZSTR_VAL(username), ZSTR_LEN(username), ZSTR_VAL(pubkey), ZSTR_LEN(pubkey), ZSTR_VAL(privkey), ZSTR_LEN(privkey), ZSTR_VAL(passphrase))) {
+	if (libssh2_userauth_publickey_frommemory(session, ZSTR_VAL(username), ZSTR_LEN(username), ZSTR_VAL(pubkey), ZSTR_LEN(pubkey), ZSTR_VAL(privkey), ZSTR_LEN(privkey), passphrase ? ZSTR_VAL(passphrase) : NULL)) {
 		char *buf;
 		int len;
 		libssh2_session_last_error(session, &buf, &len, 0);


### PR DESCRIPTION
The ssh2 extension segfaults in certain circumstances when using `ssh2_auth_pubkey` and `ssh2_auth_pubkey_file` without a password.

This has been reported 2020-06-15 at https://bugs.php.net/bug.php?id=79702 and a patch was provided at 2021-04-09 by thomas at shadowweb dot org.

This PR contains two commits:
- Thomas' original patch for `ssh2_auth_pubkey_file`
- A patch for `ssh2_auth_pubkey` that was added after the original patch had been written.

Resolves: https://bugs.php.net/bug.php?id=79702