### PR TITLE
Add ssh2_send_signal

### DIFF
--- a/php_ssh2.h
+++ b/php_ssh2.h
@@ -132,6 +132,7 @@ PHP_FUNCTION(ssh2_tunnel);
 PHP_FUNCTION(ssh2_scp_recv);
 PHP_FUNCTION(ssh2_scp_send);
 PHP_FUNCTION(ssh2_fetch_stream);
+PHP_FUNCTION(ssh2_send_signal);
 PHP_FUNCTION(ssh2_send_eof);
 PHP_FUNCTION(ssh2_shell_resize);
 

--- a/ssh2.c
+++ b/ssh2.c
@@ -1514,6 +1514,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_poll, 0, 0, 1)
  	ZEND_ARG_INFO(0, timeout)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_send_signal, 0, 0, 2)
+	ZEND_ARG_INFO(0, channel)
+	ZEND_ARG_INFO(0, signal)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_send_eof, 0, 0, 1)
 	ZEND_ARG_INFO(0, channel)
 ZEND_END_ARG_INFO()
@@ -1630,6 +1635,7 @@ zend_function_entry ssh2_functions[] = {
 	PHP_FE(ssh2_scp_send,						arginfo_ssh2_scp_send)
 	PHP_FE(ssh2_fetch_stream,					arginfo_ssh2_fetch_stream)
 	PHP_FE(ssh2_poll,							arginfo_ssh2_poll)
+	PHP_FE(ssh2_send_signal,                    arginfo_ssh2_send_signal)
 	PHP_FE(ssh2_send_eof,						arginfo_ssh2_send_eof)
 	PHP_FE(ssh2_shell_resize,                   arginfo_ssh2_shell_resize)
 

--- a/ssh2_fopen_wrappers.c
+++ b/ssh2_fopen_wrappers.c
@@ -1483,6 +1483,42 @@ PHP_FUNCTION(ssh2_fetch_stream)
 }
 /* }}} */
 
+/* {{{ proto bool ssh2_send_signal(stream channel, string signal)
+ * Sends a signal to a stream.
+ */
+PHP_FUNCTION(ssh2_send_signal)
+{
+	php_ssh2_channel_data *data;
+	php_stream *parent;
+	zval *zparent;
+	zend_string *signal;
+	int ssh2_ret;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rS", &zparent, &signal) == FAILURE) {
+		return;
+	}
+
+	php_stream_from_zval(parent, zparent);
+	if (parent->ops != &php_ssh2_channel_stream_ops) {
+		php_error_docref(NULL, E_WARNING, "Provided stream is not of type " PHP_SSH2_CHANNEL_STREAM_NAME);
+		RETURN_FALSE;
+	}
+
+	data = (php_ssh2_channel_data*)parent->abstract;
+	if (!data) {
+		php_error_docref(NULL, E_WARNING, "Abstract in stream is null");
+		RETURN_FALSE;
+	}
+
+	ssh2_ret = libssh2_channel_signal_ex(data->channel, signal->val, signal->len);
+	if (ssh2_ret < 0) {
+		php_error_docref(NULL, E_WARNING, "Couldn't send signal %s to channel (Return code %d)", signal->val, ssh2_ret);
+		RETURN_FALSE;
+	}
+
+	RETURN_TRUE;
+}
+
 /* {{{ proto stream ssh2_send_eof(stream channel)
  * Sends EOF to a stream. Primary use is to close stdin of an stdio stream.
  */

--- a/tests/ssh2_send_signal.phpt
+++ b/tests/ssh2_send_signal.phpt
@@ -1,0 +1,24 @@
+--TEST--
+ssh2_send_signal() - Tests sending signal to process
+--SKIPIF--
+<?php require('ssh2_skip.inc'); ssh2t_needs_auth(); ?>
+--FILE--
+<?php require('ssh2_test.inc');
+
+$ssh = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+var_dump(ssh2t_auth($ssh));
+
+$cmd = ssh2_exec($ssh, 'bash -c \'trap "echo success" SIGINT; sleep infinity\'');
+var_dump($cmd);
+
+$result = ssh2_send_signal($cmd, 'INT');
+var_dump($result);
+
+$stdout = stream_get_contents($cmd);
+echo $stdout;
+
+--EXPECTF--
+bool(true)
+resource(%d) of type (stream)
+bool(true)
+success


### PR DESCRIPTION
Just as the title says; AFAIK there's no way of doing this without exposing `libssh2_channel_signal_ex`.

Hopefully test passes.