### PR TITLE
PHP 8.6 compatibility: Replace zval_is_true

### DIFF
--- a/ssh2.c
+++ b/ssh2.c
@@ -158,7 +158,7 @@ LIBSSH2_MACERROR_FUNC(php_ssh2_macerror_cb)
 	if (FAILURE == call_user_function(NULL, NULL, data->macerror_cb, &zretval, 1, args)) {
 		php_error_docref(NULL, E_WARNING, "Failure calling macerror callback");
 	} else {
-		retval = zval_is_true(&zretval) ? 0 : -1;
+		retval = zend_is_true(&zretval) ? 0 : -1;
 	}
 	if (Z_TYPE_P(&zretval) != IS_UNDEF) {
 		zval_ptr_dtor(&zretval);


### PR DESCRIPTION
It is defined for PHP 8.0-8.5 in Zend/zend_operators.h as

#define zval_is_true(op) \
        zend_is_true(op)

The original commit adding it to php-src was 27dc598, the commit finally removing it and replacing every use of it by zend_is_true() was commit 985d681.